### PR TITLE
Add autoplay patch

### DIFF
--- a/prerendering.bs
+++ b/prerendering.bs
@@ -725,7 +725,7 @@ Add {{[DelayWhilePrerendering]}} to {{Navigator/requestMediaKeySystemAccess()}}.
 
 <h4 id="autoplay-patch">Media Autoplay</h4>
 
-Modify the [=playing the media resource=] section to indicate that the the [=current playback position=] of a	{{HTMLMediaElement}} must increase monotonically only when the |document| is not {{Document/prerendering}}.
+Modify the [=playing the media resource=] section to indicate that the the [=current playback position=] of a	{{HTMLMediaElement}} must increase monotonically only when the {{Document}} is not {{Document/prerendering}}.
 
 <h3 id="implicitly-restricted">Implicitly restricted APIs</h3>
 

--- a/prerendering.bs
+++ b/prerendering.bs
@@ -50,6 +50,8 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
       text: resulting URL record
     urlPrefix: webappapis.html
       text: script; url: concept-script
+    urlPrefix: media.html
+      text: playing the media resource; url: playing-the-media-resource
 spec: geolocation; urlPrefix: https://w3c.github.io/geolocation-api/
   type: method; for: Geolocation
     text: getCurrentPosition(successCallback, errorCallback, options); url: getcurrentposition-method
@@ -720,6 +722,10 @@ Add {{[DelayWhilePrerendering]}} to {{ScreenOrientation/unlock()}}.
 <h4 id="eme-patch">Encrypted Media Extensions</h4>
 
 Add {{[DelayWhilePrerendering]}} to {{Navigator/requestMediaKeySystemAccess()}}.
+
+<h4 id="autoplay-patch">Media Autoplay</h4>
+
+Modify the [=playing the media resource=] section to indicate that the the [=current playback position=] of a	{{HTMLMediaElement}} must increase monotonically only when the |document| is not {{Document/prerendering}}.
 
 <h3 id="implicitly-restricted">Implicitly restricted APIs</h3>
 

--- a/prerendering.bs
+++ b/prerendering.bs
@@ -52,6 +52,7 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
       text: script; url: concept-script
     urlPrefix: media.html
       text: playing the media resource; url: playing-the-media-resource
+      text: current playback position; url: current-playback-position
 spec: geolocation; urlPrefix: https://w3c.github.io/geolocation-api/
   type: method; for: Geolocation
     text: getCurrentPosition(successCallback, errorCallback, options); url: getcurrentposition-method


### PR DESCRIPTION
When media is playing, it should still appear to be playing in the context of the prerendered page.
However, the monotonic time progression of the media element would be stalled until the page is active.

This is different from the behavior of opening the page in a new tab, as in the case of new tabs the video starts running﻿
while in the case of a prerendered page you don't want prerendering to change the behavior of media elements in that way.
