### PR TITLE
Trigger prefetch within the speculation rules spec.

### DIFF
--- a/prefetch.bs
+++ b/prefetch.bs
@@ -407,5 +407,11 @@ The <dfn>list of sufficiently strict speculative navigation referrer policies</d
     1. If |partitionKey| is equal to (|topLevelSite|, |secondKey|), then [=partitioned prefetch=] given |document|, |url| and |referrerPolicy|.
     1. Otherwise, [=uncredentialed prefetch=] given |document|, |url| and |referrerPolicy|.
 
-    <div class="note">This determines whether the navigation would use the same network partition key. If it would, the prefetch is restricted to the same partition. Otherwise it is uncredentialed.</div>
+    <div class="note">
+      This determines whether the navigation would use the same network partition key.
+
+      If it would, the prefetch is restricted to the same partition, and redirects which would leave the partition cause the prefetch to fail.
+
+      Otherwise it is uncredentialed, and redirects which would return to the original partition (thus ought to have credentials) will cause the prefetch to fail.
+    </div>
 </div>

--- a/prefetch.bs
+++ b/prefetch.bs
@@ -401,7 +401,7 @@ The <dfn>list of sufficiently strict speculative navigation referrer policies</d
     To <dfn export>prefetch</dfn> given a {{Document}} |document|, [=URL=] |url| and [=referrer policy=] |referrerPolicy|, perform the following steps.
 
     1. Let |partitionKey| be the result of [=determining the network partition key=] given |document|'s [=relevant settings object=].
-    1. Let |topLevelOrigin| be |document|'s [=relevant settings object=]'s [=environment/top-level origin=] if |document|'s [=Document/browsing context=] is not a [=top-level browsing context=], and |url|'s [=origin=] otherwise.
+    1. Let |topLevelOrigin| be |url|'s [=url/origin=] if |document|'s [=Document/browsing context=] is a [=top-level browsing context=], and |document|'s [=relevant settings object=]'s [=environment/top-level origin=] otherwise.
     1. Let |topLevelSite| be the result of [=obtaining a site=], given |topLevelOrigin|.
     1. Let |secondKey| be null or an [=implementation-defined=] value.
     1. If |partitionKey| is equal to (|topLevelSite|, |secondKey|), then [=partitioned prefetch=] given |document|, |url| and |referrerPolicy|.

--- a/prefetch.bs
+++ b/prefetch.bs
@@ -396,3 +396,16 @@ The <dfn>list of sufficiently strict speculative navigation referrer policies</d
 
     <div class="issue">Further review is needed of the cookies-present handling and its interaction with redirects and caches.</div>
 </div>
+
+<div algorithm>
+    To <dfn export>prefetch</dfn> given a {{Document}} |document|, [=URL=] |url| and [=referrer policy=] |referrerPolicy|, perform the following steps.
+
+    1. Let |partitionKey| be the result of [=determining the network partition key=] given |document|'s [=relevant settings object=].
+    1. Let |topLevelOrigin| be |document|'s [=relevant settings object=]'s [=environment/top-level origin=] if |document|'s [=Document/browsing context=] is not a [=top-level browsing context=], and |url|'s [=origin=] otherwise.
+    1. Let |topLevelSite| be the result of [=obtaining a site=], given |topLevelOrigin|.
+    1. Let |secondKey| be null or an [=implementation-defined=] value.
+    1. If |partitionKey| is equal to (|topLevelSite|, |secondKey|), then [=partitioned prefetch=] given |document|, |url| and |referrerPolicy|.
+    1. Otherwise, [=uncredentialed prefetch=] given |document|, |url| and |referrerPolicy|.
+
+    <div class="note">This determines whether the navigation would use the same network partition key. If it would, the prefetch is restricted to the same partition. Otherwise it is uncredentialed.</div>
+</div>

--- a/speculation-rules.bs
+++ b/speculation-rules.bs
@@ -208,6 +208,8 @@ Periodically, for any [=document=] |document|, the user agent may [=queue a glob
       1. Let |requiresAnonymousClientIPWhenCrossOrigin| be true if |rule|'s [=speculation rule/requirements=] [=set/contains=] "`anonymous-client-ip-when-cross-origin`", and false otherwise.
       1. [=list/For each=] |url| of |rule|'s [=speculation rule/URLs=]:
         1. The user agent may [=prefetch=] |url| given |document|, |url| and "`strict-origin-when-cross-origin`". If |requiresAnonymousClientIPWhenCrossOrigin| is true, it must not do so unless it can obscure the user's client IP address for any request for a URL whose [=url/origin=] is not [=same origin=] to |document|'s [=Document/origin=].
+
+            <p class="issue">At the moment, how IP anonymization is achieved is handwaved. This will probably be done in an [=implementation-defined=] manner using some kind of proxy or relay. Ideally this would be plumbed down to [=obtain a connection=], and possibly even the mechanism could be further standardized.</p>
 </div>
 
 <p class="issue">

--- a/speculation-rules.bs
+++ b/speculation-rules.bs
@@ -23,6 +23,9 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
   type: dfn
     urlPrefix: webappapis.html
       text: script; url: concept-script
+spec: nav-speculation; urlPrefix: prefetch.html
+  type: dfn
+    text: prefetch; url: prefetch
 </pre>
 <style>
 /* domintro from https://resources.whatwg.org/standard.css */
@@ -204,8 +207,7 @@ Periodically, for any [=document=] |document|, the user agent may [=queue a glob
     1. [=list/For each=] |rule| of |ruleSet|'s [=speculation rule set/prefetch rules=]:
       1. Let |requiresAnonymousClientIPWhenCrossOrigin| be true if |rule|'s [=speculation rule/requirements=] [=set/contains=] "`anonymous-client-ip-when-cross-origin`", and false otherwise.
       1. [=list/For each=] |url| of |rule|'s [=speculation rule/URLs=]:
-        1. The user agent may prefetch |url| given |requiresAnonymousClientIPWhenCrossOrigin|.
-           <p class="issue">TODO: expand this to actually elaborate on how prefetch works, once initiated, and to incorporate the |requiresAnonymousClientIPWhenCrossOrigin| flag. We may wish to include language about when the UA should deduplicate requests.
+        1. The user agent may [=prefetch=] |url| given |document|, |url| and "`strict-origin-when-cross-origin`". If |requiresAnonymousClientIPWhenCrossOrigin| is true, it must not do so unless it can obscure the user's client IP address for any request for a URL whose [=url/origin=] is not [=same origin=] to |document|'s [=Document/origin=].
 </div>
 
 <p class="issue">


### PR DESCRIPTION
Now that there's a definition of prefetch to link to, link to it.

The partitioned version is necessary for this to be useful for same-site cases in top-level browsing contexts; the uncredentialed version is used for cross-site cases. This meshes slightly awkwardly with the same-origin concept used in other places.