### PR TITLE
Plumb IP anonymization into prefetch, and use it to set Sec-Purpose.

### DIFF
--- a/prefetch.bs
+++ b/prefetch.bs
@@ -158,7 +158,7 @@ A <dfn export>prefetch IP anonymization policy</dfn> is either null or a [=tuple
 
   1. If |policy| is a tuple and |policy|[0] is "`anonymous-client-ip-when-cross-origin`", then:
       1. Let |origin| be |policy|[1].
-      1. Use |request|'s [=request/URL=]'s [=url/origin=] is the [=same origin|same=] as |origin|, then return false.
+      1. If |request|'s [=request/URL=]'s [=url/origin=] is the [=same origin|same=] as |origin|, then return false.
       1. Return true.
   1. [=Assert=]: |policy| is null.
   1. Return false.

--- a/prefetch.bs
+++ b/prefetch.bs
@@ -312,9 +312,7 @@ These algorithms are based on [=process a navigate fetch=].
             1. Add a parameter whose key is "`anonymous-client-ip`" and whose value is true to the "`prefetch`" token in |purpose|.
             1. The user agent must use a [=connection=] which anonymizes the client IP address (e.g., using a proxy) when fetching |request|, or return "`Blocked`".
 
-                <div class="issue">
-                  Ideally this concept would be plumbed through to the [=obtain a connection=] algorithm eventually.
-                </div>
+                <p class="issue">At the moment, how IP anonymization is achieved is handwaved. This will probably be done in an [=implementation-defined=] manner using some kind of proxy or relay. Ideally this would be plumbed down to [=obtain a connection=], and possibly even the mechanism could be further standardized.</p>
         1. [=header list/Set a structured field value=] given (<a http-header>`` `Sec-Purpose` ``</a>, |purpose|) in |request|'s [=request/header list=].
 
             <div class="note">
@@ -387,9 +385,7 @@ The <dfn>list of sufficiently strict speculative navigation referrer policies</d
             1. Add a parameter whose key is "`anonymous-client-ip`" and whose value is true to the "`prefetch`" token in |purpose|.
             1. The user agent must use a [=connection=] which anonymizes the client IP address (e.g., using a proxy) when fetching |request|, or return "`Blocked`".
 
-                <div class="issue">
-                  Ideally this concept would be plumbed through to the [=obtain a connection=] algorithm eventually.
-                </div>
+                <p class="issue">At the moment, how IP anonymization is achieved is handwaved. This will probably be done in an [=implementation-defined=] manner using some kind of proxy or relay. Ideally this would be plumbed down to [=obtain a connection=], and possibly even the mechanism could be further standardized.</p>
         1. [=header list/Set a structured field value=] given (<a http-header>`` `Sec-Purpose` ``</a>, |purpose|) in |request|'s [=request/header list=].
 
             <div class="note">

--- a/prefetch.bs
+++ b/prefetch.bs
@@ -461,7 +461,7 @@ It may contain a <a spec="RFC8941">Item</a> member which is the <a spec="RFC8941
 
 The following parameters are defined for the "`prefetch`" token:
 
-* A parameter whose key is <dfn export for="Sec-Purpose prefetch" lt="anonymous-client-ip">"`anonymous-client-ip`"</dfn>.
+* A parameter whose key is <dfn for="Sec-Purpose prefetch" lt="anonymous-client-ip">"`anonymous-client-ip`"</dfn>.
 
   If present with a value other than boolean false (`` `?0` `` in the field value), this parameter indicates that the prefetch request is being made using an anonymous client IP. Consequently, servers should not rely on it matching, or sharing a geographic location or network operator with, the client's IP address from which a non-prefetch request would have been made.
 

--- a/prefetch.bs
+++ b/prefetch.bs
@@ -151,14 +151,15 @@ The user agent may remove elements from the [=prefetch buffer=] even if they are
     1. Return |navigationParams|.
 </div>
 
-A <dfn export>prefetch IP anonymization policy</dfn> is either null or a [=tuple=] consisting of the string "`anonymous-client-ip-when-cross-origin`" and an [=origin=].
+A <dfn export>prefetch IP anonymization policy</dfn> is either null or a [=cross-origin prefetch IP anonymization policy=].
+
+A <dfn export>cross-origin prefetch IP anonymization policy</dfn> has an <dfn export for="cross-origin prefetch IP anonymization policy">origin</dfn>, which is an [=origin=].
 
 <div algorithm>
   A [=prefetch IP anonymization policy=] |policy| <dfn for="prefetch IP anonymization policy">requires anonymity</dfn> for [=request=] |request| if the following steps return true:
 
-  1. If |policy| is a tuple and |policy|[0] is "`anonymous-client-ip-when-cross-origin`", then:
-      1. Let |origin| be |policy|[1].
-      1. If |request|'s [=request/URL=]'s [=url/origin=] is the [=same origin|same=] as |origin|, then return false.
+  1. If |policy| is a [=cross-origin prefetch IP anonymization policy=]:
+      1. If |request|'s [=request/URL=]'s [=url/origin=] is the [=same origin|same=] as |policy|'s [=cross-origin prefetch IP anonymization policy/origin=], then return false.
       1. Return true.
   1. [=Assert=]: |policy| is null.
   1. Return false.

--- a/prefetch.bs
+++ b/prefetch.bs
@@ -310,7 +310,7 @@ These algorithms are based on [=process a navigate fetch=].
         1. [=Assert=]: |request|'s [=request/reserved client=] is |environment|.
         1. Let |purpose| be a <a spec="RFC8941">List</a> containing the <a spec="RFC8941">Token</a> "`prefetch`".
         1. If |anonymizationPolicy| [=prefetch IP anonymization policy/requires anonymity=] for |request|, then:
-            1. Add a parameter whose key is "`anonymous-client-ip`" and whose value is true to the "`prefetch`" token in |purpose|.
+            1. Add a parameter whose key is <a for="Sec-Purpose prefetch" lt="anonymous-client-ip">"`anonymous-client-ip`"</a> and whose value is true to the "`prefetch`" token in |purpose|.
             1. The user agent must use a [=connection=] which anonymizes the client IP address (e.g., using a proxy) when fetching |request|, or return "`Blocked`".
 
                 <p class="issue">At the moment, how IP anonymization is achieved is handwaved. This will probably be done in an [=implementation-defined=] manner using some kind of proxy or relay. Ideally this would be plumbed down to [=obtain a connection=], and possibly even the mechanism could be further standardized.</p>
@@ -383,7 +383,7 @@ The <dfn>list of sufficiently strict speculative navigation referrer policies</d
         1. [=Assert=]: |navigationType| is "`other`".
         1. Let |purpose| be a <a spec="RFC8941">List</a> containing the <a spec="RFC8941">Token</a> "`prefetch`".
         1. If |anonymizationPolicy| [=prefetch IP anonymization policy/requires anonymity=] for |request|, then:
-            1. Add a parameter whose key is "`anonymous-client-ip`" and whose value is true to the "`prefetch`" token in |purpose|.
+            1. Add a parameter whose key is <a for="Sec-Purpose prefetch" lt="anonymous-client-ip">"`anonymous-client-ip`"</a> and whose value is true to the "`prefetch`" token in |purpose|.
             1. The user agent must use a [=connection=] which anonymizes the client IP address (e.g., using a proxy) when fetching |request|, or return "`Blocked`".
 
                 <p class="issue">At the moment, how IP anonymization is achieved is handwaved. This will probably be done in an [=implementation-defined=] manner using some kind of proxy or relay. Ideally this would be plumbed down to [=obtain a connection=], and possibly even the mechanism could be further standardized.</p>
@@ -461,7 +461,7 @@ It may contain a <a spec="RFC8941">Item</a> member which is the <a spec="RFC8941
 
 The following parameters are defined for the "`prefetch`" token:
 
-* A parameter whose key is "`anonymous-client-ip`".
+* A parameter whose key is <dfn export for="Sec-Purpose prefetch" lt="anonymous-client-ip">"`anonymous-client-ip`"</dfn>.
 
   If present with a value other than boolean false (`` `?0` `` in the field value), this parameter indicates that the prefetch request is being made using an anonymous client IP. Consequently, servers should not rely on it matching, or sharing a geographic location or network operator with, the client's IP address from which a non-prefetch request would have been made.
 

--- a/prefetch.bs
+++ b/prefetch.bs
@@ -151,6 +151,19 @@ The user agent may remove elements from the [=prefetch buffer=] even if they are
     1. Return |navigationParams|.
 </div>
 
+A <dfn export>prefetch IP anonymization policy</dfn> is either null or a [=tuple=] consisting of the string "`anonymous-client-ip-when-cross-origin`" and an [=origin=].
+
+<div algorithm>
+  A [=prefetch IP anonymization policy=] |policy| <dfn for="prefetch IP anonymization policy">requires anonymity</dfn> for [=request=] |request| if the following steps return true:
+
+  1. If |policy| is a tuple and |policy|[0] is "`anonymous-client-ip-when-cross-origin`", then:
+      1. Let |origin| be |policy|[1].
+      1. Use |request|'s [=request/URL=]'s [=url/origin=] is the [=same origin|same=] as |origin|, then return false.
+      1. Return true.
+  1. [=Assert=]: |policy| is null.
+  1. Return false.
+</div>
+
 <h2 id="html-patches">HTML Patches</h2>
 
 <div algorithm="perform a common navigational fetch">
@@ -264,7 +277,7 @@ These algorithms are based on [=process a navigate fetch=].
 <p class="issue">Check Service Worker integration</p>
 
 <div algorithm="partitioned prefetch">
-    To <dfn export>partitioned prefetch</dfn> given a {{Document}} |document|, [=URL=] |url| and [=referrer policy=] |referrerPolicy|, perform the following steps.
+    To <dfn export>partitioned prefetch</dfn> given a {{Document}} |document|, [=URL=] |url|, [=referrer policy=] |referrerPolicy|, and [=prefetch IP anonymization policy=] |anonymizationPolicy|, perform the following steps.
 
     1. [=Assert=]: |url|'s [=url/scheme=] is an [=HTTP(S) scheme=].
     1. Let |partitionKey| be the result of [=determining the network partition key=] given |document|'s [=relevant settings object=].
@@ -289,18 +302,24 @@ These algorithms are based on [=process a navigate fetch=].
         :  [=request/client=]
         :: |document|'s [=relevant settings object=]
         :  [=request/header list=]
-        ::
-            *  `` `Sec-Purpose` ``/`` `prefetch` ``
 
-                <div class="note">
-                    Implementations might also send vendor-specific headers, like Chromium's `` `Purpose` ``/`` `prefetch` ``, Mozilla's `` `X-moz` ``/`` `prefetch` ``, and WebKit's `` `X-Purpose` ``/`` `preview` ``, for compatibility with existing server software. Over time we hope implementers and server software authors will adopt a standard header.
-                </div>
-
-                <div class="issue">TODO: Emit the "`anonymous-client-ip`" parameter when applicable.</div>
     1. Let |redirectChain| be an empty [=list=].
     1. Let |shouldBlockNavigationRequest| be the following steps, given [=request=] |request|, [=string=] |navigationType| and [=environment=] |environment|:
         1. [=Assert=]: |navigationType| is "`other`".
         1. [=Assert=]: |request|'s [=request/reserved client=] is |environment|.
+        1. Let |purpose| be a <a spec="RFC8941">List</a> containing the <a spec="RFC8941">Token</a> "`prefetch`".
+        1. If |anonymizationPolicy| [=prefetch IP anonymization policy/requires anonymity=] for |request|, then:
+            1. Add a parameter whose key is "`anonymous-client-ip`" and whose value is true to the "`prefetch`" token in |purpose|.
+            1. The user agent must use a [=connection=] which anonymizes the client IP address (e.g., using a proxy) when fetching |request|, or return "`Blocked`".
+
+                <div class="issue">
+                  Ideally this concept would be plumbed through to the [=obtain a connection=] algorithm eventually.
+                </div>
+        1. [=header list/Set a structured field value=] given (<a http-header>`` `Sec-Purpose` ``</a>, |purpose|) in |request|'s [=request/header list=].
+
+            <div class="note">
+                Implementations might also send vendor-specific headers, like Chromium's `` `Purpose` ``/`` `prefetch` ``, Mozilla's `` `X-moz` ``/`` `prefetch` ``, and WebKit's `` `X-Purpose` ``/`` `preview` ``, for compatibility with existing server software. Over time we hope implementers and server software authors will adopt a standard header.
+            </div>
         1. Let |proposedPartitionKey| be the result of [=determining the network partition key=] given |request|.
         1. If |partitionKey| is not equal to |proposedPartitionKey|, then return "`Blocked`".
 
@@ -326,7 +345,7 @@ These algorithms are based on [=process a navigate fetch=].
 The <dfn>list of sufficiently strict speculative navigation referrer policies</dfn> is a list containing the following: "", "`strict-origin-when-cross-origin`", "`strict-origin`", "`same-origin`", "`no-referrer`".
 
 <div algorithm="uncredentialed prefetch">
-    To <dfn export>uncredentialed prefetch</dfn> given a {{Document}} |document|, [=URL=] |url| and [=referrer policy=] |referrerPolicy|, perform the following steps.
+    To <dfn export>uncredentialed prefetch</dfn> given a {{Document}} |document|, [=URL=] |url|, [=referrer policy=] |referrerPolicy|, and [=prefetch IP anonymization policy=] |anonymizationPolicy|, perform the following steps.
 
     1. [=Assert=]: |url|'s [=url/scheme=] is an [=HTTP(S) scheme=].
     1. If |referrerPolicy| is not in the [=list of sufficiently strict speculative navigation referrer policies=], then return.
@@ -357,21 +376,25 @@ The <dfn>list of sufficiently strict speculative navigation referrer policies</d
         :: "`no-store`"
         :  [=request/client=]
         :: |document|'s [=relevant settings object=]
-        :  [=request/header list=]
-        ::
-            *  `` `Sec-Purpose` ``/`` `prefetch` ``
-
-                <div class="note">
-                    Implementations might also send vendor-specific headers, like Chromium's `` `Purpose` ``/`` `prefetch` ``, Mozilla's `` `X-moz` ``/`` `prefetch` ``, and WebKit's `` `X-Purpose` ``/`` `preview` ``, for compatibility with existing server software. Over time we hope implementers and server software authors will adopt a standard header.
-                </div>
-
-                <div class="issue">TODO: Emit the "`anonymous-client-ip`" parameter when applicable.</div>
 
     1. Let |originsWithConflictingCredentials| be an empty [=ordered set=].
     1. Let |redirectChain| be an empty [=list=].
     1. Let |shouldBlockNavigationRequest| be the following steps, given [=request=] |request|, [=string=] |navigationType| and [=environment=] |environment|:
         1. [=Assert=]: |request|'s [=request/reserved client=] is |isolatedEnvironment| and not |environment|.
         1. [=Assert=]: |navigationType| is "`other`".
+        1. Let |purpose| be a <a spec="RFC8941">List</a> containing the <a spec="RFC8941">Token</a> "`prefetch`".
+        1. If |anonymizationPolicy| [=prefetch IP anonymization policy/requires anonymity=] for |request|, then:
+            1. Add a parameter whose key is "`anonymous-client-ip`" and whose value is true to the "`prefetch`" token in |purpose|.
+            1. The user agent must use a [=connection=] which anonymizes the client IP address (e.g., using a proxy) when fetching |request|, or return "`Blocked`".
+
+                <div class="issue">
+                  Ideally this concept would be plumbed through to the [=obtain a connection=] algorithm eventually.
+                </div>
+        1. [=header list/Set a structured field value=] given (<a http-header>`` `Sec-Purpose` ``</a>, |purpose|) in |request|'s [=request/header list=].
+
+            <div class="note">
+                Implementations might also send vendor-specific headers, like Chromium's `` `Purpose` ``/`` `prefetch` ``, Mozilla's `` `X-moz` ``/`` `prefetch` ``, and WebKit's `` `X-Purpose` ``/`` `preview` ``, for compatibility with existing server software. Over time we hope implementers and server software authors will adopt a standard header.
+            </div>
         1. Let |hypotheticalPartitionKey| be the result of [=determining the network partition key=] given |environment|.
         1. If |originalPartitionKey| is equal to |hypotheticalPartitionKey|, then return "`Blocked`".
 
@@ -407,14 +430,14 @@ The <dfn>list of sufficiently strict speculative navigation referrer policies</d
 </div>
 
 <div algorithm>
-    To <dfn export>prefetch</dfn> given a {{Document}} |document|, [=URL=] |url| and [=referrer policy=] |referrerPolicy|, perform the following steps.
+    To <dfn export>prefetch</dfn> given a {{Document}} |document|, [=URL=] |url|, [=referrer policy=] |referrerPolicy|, and [=prefetch IP anonymization policy=] |anonymizationPolicy|, perform the following steps.
 
     1. Let |partitionKey| be the result of [=determining the network partition key=] given |document|'s [=relevant settings object=].
     1. Let |topLevelOrigin| be |url|'s [=url/origin=] if |document|'s [=Document/browsing context=] is a [=top-level browsing context=], and |document|'s [=relevant settings object=]'s [=environment/top-level origin=] otherwise.
     1. Let |topLevelSite| be the result of [=obtaining a site=], given |topLevelOrigin|.
     1. Let |secondKey| be null or an [=implementation-defined=] value.
-    1. If |partitionKey| is equal to (|topLevelSite|, |secondKey|), then [=partitioned prefetch=] given |document|, |url| and |referrerPolicy|.
-    1. Otherwise, [=uncredentialed prefetch=] given |document|, |url| and |referrerPolicy|.
+    1. If |partitionKey| is equal to (|topLevelSite|, |secondKey|), then [=partitioned prefetch=] given |document|, |url|, |referrerPolicy| and |anonymizationPolicy|.
+    1. Otherwise, [=uncredentialed prefetch=] given |document|, |url|, |referrerPolicy| and |anonymizationPolicy|.
 
     <div class="note">
       This determines whether the navigation would use the same network partition key.

--- a/speculation-rules.bs
+++ b/speculation-rules.bs
@@ -196,9 +196,7 @@ Periodically, for any [=document=] |document|, the user agent may [=queue a glob
     1. [=list/For each=] |rule| of |ruleSet|'s [=speculation rule set/prefetch rules=]:
       1. Let |anonymizationPolicy| be ("`anonymous-client-ip-when-cross-origin`", |document|'s [=Document/origin=]) if |rule|'s [=speculation rule/requirements=] [=set/contains=] "`anonymous-client-ip-when-cross-origin`", and null otherwise.
       1. [=list/For each=] |url| of |rule|'s [=speculation rule/URLs=]:
-        1. The user agent may [=prefetch=] |url| given |document|, |url|, "`strict-origin-when-cross-origin`" and |anonymizationPolicy|. If |requiresAnonymousClientIPWhenCrossOrigin| is true, it must not do so unless it can obscure the user's client IP address for any request for a URL whose [=url/origin=] is not [=same origin=] to |document|'s [=Document/origin=].
-
-            <p class="issue">At the moment, how IP anonymization is achieved is handwaved. This will probably be done in an [=implementation-defined=] manner using some kind of proxy or relay. Ideally this would be plumbed down to [=obtain a connection=], and possibly even the mechanism could be further standardized.</p>
+        1. The user agent may [=prefetch=] |url| given |document|, |url|, "`strict-origin-when-cross-origin`" and |anonymizationPolicy|.
 </div>
 
 <p class="issue">

--- a/speculation-rules.bs
+++ b/speculation-rules.bs
@@ -26,6 +26,8 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
 spec: nav-speculation; urlPrefix: prefetch.html
   type: dfn
     text: prefetch; url: prefetch
+    text: cross-origin prefetch IP anonymization policy; url: cross-origin-prefetch-ip-anonymization-policy
+    text: origin; for: cross-origin prefetch IP anonymization policy; url: cross-origin-prefetch-ip-anonymization-policy-origin
 </pre>
 <style>
 /* domintro from https://resources.whatwg.org/standard.css */
@@ -194,7 +196,8 @@ Periodically, for any [=document=] |document|, the user agent may [=queue a glob
      <p class="issue">It's likely that we should also handle prerendered and back-forward cached documents.
   1. For each |ruleSet| of |document|'s [=document/list of speculation rule sets=]:
     1. [=list/For each=] |rule| of |ruleSet|'s [=speculation rule set/prefetch rules=]:
-      1. Let |anonymizationPolicy| be ("`anonymous-client-ip-when-cross-origin`", |document|'s [=Document/origin=]) if |rule|'s [=speculation rule/requirements=] [=set/contains=] "`anonymous-client-ip-when-cross-origin`", and null otherwise.
+      1. Let |anonymizationPolicy| be null.
+      1. If |rule|'s [=speculation rule/requirements=] [=set/contains=] "`anonymous-client-ip-when-cross-origin`", set |anonymizationPolicy| to a [=cross-origin prefetch IP anonymization policy=] whose [=cross-origin prefetch IP anonymization policy/origin=] is |document|'s [=Document/origin=].
       1. [=list/For each=] |url| of |rule|'s [=speculation rule/URLs=]:
         1. The user agent may [=prefetch=] |url| given |document|, |url|, "`strict-origin-when-cross-origin`" and |anonymizationPolicy|.
 </div>

--- a/speculation-rules.bs
+++ b/speculation-rules.bs
@@ -194,9 +194,9 @@ Periodically, for any [=document=] |document|, the user agent may [=queue a glob
      <p class="issue">It's likely that we should also handle prerendered and back-forward cached documents.
   1. For each |ruleSet| of |document|'s [=document/list of speculation rule sets=]:
     1. [=list/For each=] |rule| of |ruleSet|'s [=speculation rule set/prefetch rules=]:
-      1. Let |requiresAnonymousClientIPWhenCrossOrigin| be true if |rule|'s [=speculation rule/requirements=] [=set/contains=] "`anonymous-client-ip-when-cross-origin`", and false otherwise.
+      1. Let |anonymizationPolicy| be ("`anonymous-client-ip-when-cross-origin`", |document|'s [=Document/origin=]) if |rule|'s [=speculation rule/requirements=] [=set/contains=] "`anonymous-client-ip-when-cross-origin`", and null otherwise.
       1. [=list/For each=] |url| of |rule|'s [=speculation rule/URLs=]:
-        1. The user agent may [=prefetch=] |url| given |document|, |url| and "`strict-origin-when-cross-origin`". If |requiresAnonymousClientIPWhenCrossOrigin| is true, it must not do so unless it can obscure the user's client IP address for any request for a URL whose [=url/origin=] is not [=same origin=] to |document|'s [=Document/origin=].
+        1. The user agent may [=prefetch=] |url| given |document|, |url|, "`strict-origin-when-cross-origin`" and |anonymizationPolicy|. If |requiresAnonymousClientIPWhenCrossOrigin| is true, it must not do so unless it can obscure the user's client IP address for any request for a URL whose [=url/origin=] is not [=same origin=] to |document|'s [=Document/origin=].
 
             <p class="issue">At the moment, how IP anonymization is achieved is handwaved. This will probably be done in an [=implementation-defined=] manner using some kind of proxy or relay. Ideally this would be plumbed down to [=obtain a connection=], and possibly even the mechanism could be further standardized.</p>
 </div>


### PR DESCRIPTION
This causes this header to be sent with requests which do not require anonymization:

```
Sec-Purpose: prefetch
```

And this header to be sent with those which do:

```
Sec-Purpose: prefetch;anonymous-client-ip
```

Preview: https://api.csswg.org/bikeshed/?url=https://raw.githubusercontent.com/jeremyroman/nav-speculation/7d3fa30f431dabb2b5f027630f30790333538df1/speculation-rules.bs