### PR TITLE
Update session history

### DIFF
--- a/prerendering.bs
+++ b/prerendering.bs
@@ -362,7 +362,7 @@ Every {{Document}} has an <dfn for="Document">activation start time</dfn>, which
 
   1. Append |historyEntry| to |successorBC|'s [=session history=].
 
-  1. [=Traverse the history=] to |historyEntry| with [=Traverse the history/historyHandling=] set to |historyHandling|.
+  1. [=Traverse the history=] to |historyEntry| with |historyHandling|.
 
   1. TODO prepend the existing session history of |predecessorBC| into |successorBC|? Or, probably better, use the new "browsing session" concept to bridge them? Be sure to respect |historyHandling|.
 

--- a/prerendering.bs
+++ b/prerendering.bs
@@ -354,6 +354,16 @@ Every {{Document}} has an <dfn for="Document">activation start time</dfn>, which
 
   <!-- End copied section. -->
 
+  1. Assert: |successorBC|'s [=session history=]'s [=list/size=] is 1.
+
+  1. Let |historyEntry| be |successorBC|'s [=session history=][0].
+
+  1. Set |successorBC|'s [=session history=] to |predecessorBC|'s [=session history=].
+
+  1. Append |historyEntry| to |successorBC|'s [=session history=].
+
+  1. [=Traverse the history=] to |historyEntry| with [=Traverse the history/historyHandling=] set to |historyHandling|.
+
   1. TODO prepend the existing session history of |predecessorBC| into |successorBC|? Or, probably better, use the new "browsing session" concept to bridge them? Be sure to respect |historyHandling|.
 
   1. [=In parallel=]:


### PR DESCRIPTION
Since we're making the successor BC the current one, we need to keep the previous BC's session history, and append/replace the successor's entry. There should be only one entry due to  https://wicg.github.io/nav-speculation/prerendering.html#always-replacement, and we should take history handling into account. 