### PR TITLE
Discard wording, plus cross-origin navigation/iframes

### DIFF
--- a/prerendering.bs
+++ b/prerendering.bs
@@ -461,7 +461,7 @@ Every {{Document}} has an <dfn for="Document">activation start time</dfn>, which
 
   To ensure that the references for a [=prerendering browsing context=] are cleared once it is [=discard|discarded=], modify <a spec=HTML for="browsing context">remove</a> by appending the following step:
 
-  1. If <var ignore>browsingContext</var> is a [=prerendering browsing context=] and <var ignore>browsingContext</var>'s [=prerendering browsing context/remove from initiator=] is not Null, then call <var ignore>browsingContext</var>'s [=prerendering browsing context/remove from initiator=].
+  1. If <var ignore>browsingContext</var> is a [=prerendering browsing context=] and <var ignore>browsingContext</var>'s [=prerendering browsing context/remove from initiator=] is not null, then call <var ignore>browsingContext</var>'s [=prerendering browsing context/remove from initiator=].
 </div>
 
 <h3 id="creating-bcs-patch">Modifications to creating browsing contexts</h3>

--- a/prerendering.bs
+++ b/prerendering.bs
@@ -391,13 +391,11 @@ Every {{Document}} has an <dfn for="Document">activation start time</dfn>, which
 
   1. Set |bc|'s [=prerendering browsing context/remove from initiator=] be to [=map/remove=] |referrerDoc|[|startingURL|].
 
+     <p class="note">As with regular [=browsing context|browsing contexts=], The [=prerendering browsing context=] can be [=discard|discarded=] for any reason, for example if it becomes unresponsive, performs a restricted operation, or if the user-agent believes prerendering takes too much resources.
+
   1. Let |request| be a new [=request=] whose [=request/URL=] is |startingURL| and [=request/referrer policy=] is |referrerPolicy|.
 
   1. [=Navigate=] |bc| to |request| with the [=source browsing context=] set to |referrerDoc|'s [=Document/browsing context=].
-
-  1. If |bc| is [=discard|discarded=], [=map/remove=] |referrerDoc|'s [=Document/prerendering browsing contexts map=][(|startingURL|, |referrerPolicy|)].
-
-     <p class="note">As with regular [=browsing context|browsing contexts=], The [=prerendering browsing context=] can be [=discard|discarded=] for any reason, for example if it becomes unresponsive, performs a restricted operation, or if the user-agent believes prerendering takes too much resources.
 
 </div>
 

--- a/prerendering.bs
+++ b/prerendering.bs
@@ -475,7 +475,7 @@ Patch the [=navigate=] algorithm to allow delaying or discarding of a cross-orig
 
   1. Let |crossOrigin| be <var ignore>hasCrossOriginRedirects</var>.
 
-  1. f |bc|'s <a spec="HTML">container</a> is not null, and |bc|'s <a spec="HTML">container</a>'s [=Node/node document=]'s	[=Document/origin=] is not [=same origin=] as <var ignore>currentURL</var>'s [=url/origin=], then set |crossOrigin| to true.
+  1. f |bc|'s <a spec="HTML">container</a> is not null, and |bc|'s <a spec="HTML">container</a>'s [=Node/node document=]'s	[=Document/origin=] is not [=same origin=] with <var ignore>currentURL</var>'s [=url/origin=], then set |crossOrigin| to true.
 
   1. If |crossOrigin| is true and |browsingContext|'s [=top-level browsing context=] is a [=prerendering browsing context=], then wait until |browsingContext| is [=prerendering browsing context/activate|activated=].
 

--- a/prerendering.bs
+++ b/prerendering.bs
@@ -479,7 +479,7 @@ Patch the [=navigate=] algorithm to allow delaying or evicting of a cross-origin
 
   1. Let |crossOrigin| be <var ignore>hasCrossOriginRedirects</var>.
 
-  1. f |bc|'s [=browsing context/container=] is not null, and |bc|'s [=browsing context/container=]'s [=node document=]'s	[=Document/origin=] is not [=same origin=] as <var ignore>currentURL</var>'s [=url/origin=], then set |crossOrigin| to true.
+  1. f |bc|'s <a lt="bc-container" spec="HTML">container</a> is not null, and |bc|'s <a lt="bc-container" spec="HTML">container</a>'s [=node document=]'s	[=Document/origin=] is not [=same origin=] as <var ignore>currentURL</var>'s [=url/origin=], then set |crossOrigin| to true.
 
   1. If |crossOrigin| is true and |browsingContext|'s [=top-level browsing context=] is a [=prerendering browsing context=], then wait until |browsingContext| is [=prerendering browsing context/activate|activated=].
 

--- a/prerendering.bs
+++ b/prerendering.bs
@@ -479,7 +479,7 @@ Patch the [=navigate=] algorithm to allow delaying or evicting of a cross-origin
 
   1. Let |crossOrigin| be <var ignore>hasCrossOriginRedirects</var>.
 
-  1. f |bc|'s <a lt="bc-container" spec="HTML">container</a> is not null, and |bc|'s <a lt="bc-container" spec="HTML">container</a>'s [=node document=]'s	[=Document/origin=] is not [=same origin=] as <var ignore>currentURL</var>'s [=url/origin=], then set |crossOrigin| to true.
+  1. f |bc|'s <a spec="HTML">container</a> is not null, and |bc|'s <a spec="HTML">container</a>'s [=node document=]'s	[=Document/origin=] is not [=same origin=] as <var ignore>currentURL</var>'s [=url/origin=], then set |crossOrigin| to true.
 
   1. If |crossOrigin| is true and |browsingContext|'s [=top-level browsing context=] is a [=prerendering browsing context=], then wait until |browsingContext| is [=prerendering browsing context/activate|activated=].
 

--- a/prerendering.bs
+++ b/prerendering.bs
@@ -468,7 +468,7 @@ Patch the [=navigate=] algorithm to allow the [=prerendering browsing context/ac
     1. Return.
 </div>
 
-Patch the [=navigate=] algorithm to allow delaying or discarding of a cross-origin navigations in a [=prerendering browsing context=] as follows:
+Patch the [=navigate=] algorithm to allow delaying or discarding of cross-origin navigations in a [=prerendering browsing context=] as follows:
 
 <div algorithm="navigate delay cross-origin patch">
   In [=navigate=], append the following steps after the cross-origin redirect check (currently step 13.1):

--- a/prerendering.bs
+++ b/prerendering.bs
@@ -457,7 +457,7 @@ Every {{Document}} has an <dfn for="Document">activation start time</dfn>, which
 </div>
 
 <div algorithm>
-  A [=prerendering browsing context=] has an associated <dfn for="prerendering browsing context">remove from initiator</dfn>, which is Null or an algorithm with no arguments, initially set to null.
+  A [=prerendering browsing context=] has an associated <dfn for="prerendering browsing context">remove from initiator</dfn>, which is null or an algorithm with no arguments, initially set to null.
 
   To ensure that the references for a [=prerendering browsing context=] are cleared once it is [=discard|discarded=], modify <a spec=HTML for="browsing context">remove</a> by appending the following step:
 

--- a/prerendering.bs
+++ b/prerendering.bs
@@ -335,9 +335,9 @@ Every {{Document}} has an <dfn for="Document">activation start time</dfn>, which
 
     <p class="note">An example of indicating commitment is pressing the Enter key in the URL bar</p>
 
-    <p class="note">TODO The user might never indicate such a commitment, or might take long enough to do
+    <p class="note">The user might never indicate such a commitment, or might take long enough to do
     so that the user agent needs to reclaim the resources used by the prerender for some more
-    immediate task. In that case the user agent can cancel the prerendering.</p>
+    immediate task. In that case the user agent can [=discard=] |bc|.</p>
 </div>
 
 <div algorithm="create a prerendering browsing context">
@@ -358,6 +358,8 @@ Every {{Document}} has an <dfn for="Document">activation start time</dfn>, which
     1. [=Assert=]: The [=list of sufficiently-strict speculative navigation referrer policies=] [=list/contains=] |referrerPolicy|.
 
   1. Set |referrerDoc|'s [=Document/prerendering browsing contexts map=][|startingURL|] to |bc|.
+
+  1. Set |bc|'s [=prerendering browsing context/remove from initiator=] be to [=map/remove=] |referrerDoc|[|startingURL|].
 
   1. Let |request| be a new [=request=] whose [=request/URL=] is |startingURL| and [=request/referrer policy=] is |referrerPolicy|.
 
@@ -426,6 +428,14 @@ Every {{Document}} has an <dfn for="Document">activation start time</dfn>, which
       <p class="note">The order here is observable for [=browsing contexts=] that share an [=event loop=], but not for those in separate event loops.
 </div>
 
+<div algorithm>
+  A [=prerendering browsing context=] has an associated <dfn for="prerendering browsing context">remove from initiator</dfn>, which is Null or an algorithm with no arguments, initially set to null.
+
+  To ensure that the references for a [=prererendering browsing context=] are cleared once it is [=discard|discarded=], modify <a spec=HTML for="browsing context">remove</a> by appending the following step:
+
+  1. If <var ignore>browsingContext</var>'s [=prerendering browsing context/remove from initiator=] is not Null, then call [=browsing context/remove from prerendering initiator=].
+</div>
+
 <h3 id="creating-bcs-patch">Modifications to creating browsing contexts</h3>
 
 <div algorithm="create a new nested browsing context patch">
@@ -468,18 +478,16 @@ Patch the [=navigate=] algorithm to allow the [=prerendering browsing context/ac
     1. Return.
 </div>
 
-Patch the [=navigate=] algorithm to allow delaying or discarding of cross-origin navigations in a [=prerendering browsing context=] as follows:
+Patch the [=process a navigate fetch=] algorithm to allow delaying or discarding of cross-origin navigations in a [=prerendering browsing context=] as follows:
 
 <div algorithm="navigate delay cross-origin patch">
   In [=navigate=], append the following steps after the cross-origin redirect check (currently step 13.1):
 
   1. Let |crossOrigin| be <var ignore>hasCrossOriginRedirects</var>.
 
-  1. f |bc|'s <a spec="HTML">container</a> is not null, and |bc|'s <a spec="HTML">container</a>'s [=Node/node document=]'s	[=Document/origin=] is not [=same origin=] with <var ignore>currentURL</var>'s [=url/origin=], then set |crossOrigin| to true.
+  1. If |bc|'s <a spec="HTML">container</a> is not null, and |bc|'s <a spec="HTML">container</a>'s [=Node/node document=]'s	[=Document/origin=] is not [=same origin=] with <var ignore>currentURL</var>'s [=url/origin=], then set |crossOrigin| to true.
 
-  1. If |crossOrigin| is true and |browsingContext|'s [=top-level browsing context=] is a [=prerendering browsing context=], then wait until |browsingContext| is [=prerendering browsing context/activate|activated=].
-
-  User agents may choose to [=discard=] a [=prerendering browsing context=] when its document or one of its iframes navigates to a cross-origin URL.
+  1. If |crossOrigin| is true and |bc|'s [=top-level browsing context=] is a [=prerendering browsing context=], then the user agent must either wait to continue this algorithm until |bc| is [=prerendering browsing context/activate|activated=], or [=discard=] |bc|'s [=top-level browsing context=].
 </div>
 
 Navigation redirects can also [=prerendering browsing context/activate=] [=prerendering browsing contexts=]. This is defined in the [[#redirect-handling]] section.

--- a/prerendering.bs
+++ b/prerendering.bs
@@ -477,9 +477,9 @@ Patch the [=navigate=] algorithm to allow delaying or evicting of a cross-origin
 <div algorithm="navigate delay cross-origin patch">
   In [=navigate=], append the following steps after the cross-origin redirect check (currently step 13.1):
 
-  1. Let |crossOrigin| be |hasCrossOriginRedirects|.
+  1. Let |crossOrigin| be <var ignore>hasCrossOriginRedirects</var>.
 
-  1. f |bc|'s [=browsing context/container=] is not null, and |bc|'s [=browsing context/container=]'s [=node document=]'s	[=Document/origin=] is not [=same origin=] as |currentURL|'s [=url/origin=], then set |crossOrigin| to true.
+  1. f |bc|'s [=browsing context/container=] is not null, and |bc|'s [=browsing context/container=]'s [=node document=]'s	[=Document/origin=] is not [=same origin=] as <var ignore>currentURL</var>'s [=url/origin=], then set |crossOrigin| to true.
 
   1. If |crossOrigin| is true and |browsingContext|'s [=top-level browsing context=] is a [=prerendering browsing context=], then wait until |browsingContext| is [=prerendering browsing context/activate|activated=].
 

--- a/prerendering.bs
+++ b/prerendering.bs
@@ -435,7 +435,7 @@ Every {{Document}} has an <dfn for="Document">activation start time</dfn>, which
 
   To ensure that the references for a [=prerendering browsing context=] are cleared once it is [=discard|discarded=], modify <a spec=HTML for="browsing context">remove</a> by appending the following step:
 
-  1. If <var ignore>browsingContext</var>'s [=prerendering browsing context/remove from initiator=] is not Null, then call [=browsing context/remove from prerendering initiator=].
+  1. If <var ignore>browsingContext</var> is a [=prerendering browsing context=] and <var ignore>browsingContext</var>'s [=prerendering browsing context/remove from initiator=] is not Null, then call [=browsing context/remove from initiator=].
 </div>
 
 <h3 id="creating-bcs-patch">Modifications to creating browsing contexts</h3>

--- a/prerendering.bs
+++ b/prerendering.bs
@@ -435,7 +435,7 @@ Every {{Document}} has an <dfn for="Document">activation start time</dfn>, which
 
   To ensure that the references for a [=prerendering browsing context=] are cleared once it is [=discard|discarded=], modify <a spec=HTML for="browsing context">remove</a> by appending the following step:
 
-  1. If <var ignore>browsingContext</var> is a [=prerendering browsing context=] and <var ignore>browsingContext</var>'s [=prerendering browsing context/remove from initiator=] is not Null, then call [=browsing context/remove from initiator=].
+  1. If <var ignore>browsingContext</var> is a [=prerendering browsing context=] and <var ignore>browsingContext</var>'s [=prerendering browsing context/remove from initiator=] is not Null, then call <var ignore>browsingContext</var>'s [=prerendering browsing context/remove from initiator=].
 </div>
 
 <h3 id="creating-bcs-patch">Modifications to creating browsing contexts</h3>

--- a/prerendering.bs
+++ b/prerendering.bs
@@ -391,7 +391,7 @@ Every {{Document}} has an <dfn for="Document">activation start time</dfn>, which
 
   1. Set |bc|'s [=prerendering browsing context/remove from initiator=] be to [=map/remove=] |referrerDoc|[|startingURL|].
 
-     <p class="note">As with regular [=browsing context|browsing contexts=], The [=prerendering browsing context=] can be [=discard|discarded=] for any reason, for example if it becomes unresponsive, performs a restricted operation, or if the user-agent believes prerendering takes too much resources.
+     <p class="note">As with regular [=browsing contexts=], the [=prerendering browsing context=] can be [=discarded=] for any reason, for example if it becomes unresponsive, performs a restricted operation, or if the user agent believes prerendering takes too much resources.
 
   1. Let |request| be a new [=request=] whose [=request/URL=] is |startingURL| and [=request/referrer policy=] is |referrerPolicy|.
 

--- a/prerendering.bs
+++ b/prerendering.bs
@@ -431,7 +431,7 @@ Every {{Document}} has an <dfn for="Document">activation start time</dfn>, which
 <div algorithm>
   A [=prerendering browsing context=] has an associated <dfn for="prerendering browsing context">remove from initiator</dfn>, which is Null or an algorithm with no arguments, initially set to null.
 
-  To ensure that the references for a [=prererendering browsing context=] are cleared once it is [=discard|discarded=], modify <a spec=HTML for="browsing context">remove</a> by appending the following step:
+  To ensure that the references for a [=prerendering browsing context=] are cleared once it is [=discard|discarded=], modify <a spec=HTML for="browsing context">remove</a> by appending the following step:
 
   1. If <var ignore>browsingContext</var>'s [=prerendering browsing context/remove from initiator=] is not Null, then call [=browsing context/remove from prerendering initiator=].
 </div>

--- a/prerendering.bs
+++ b/prerendering.bs
@@ -362,6 +362,11 @@ Every {{Document}} has an <dfn for="Document">activation start time</dfn>, which
   1. Let |request| be a new [=request=] whose [=request/URL=] is |startingURL| and [=request/referrer policy=] is |referrerPolicy|.
 
   1. [=Navigate=] |bc| to |request| with the [=source browsing context=] set to |referrerDoc|'s [=Document/browsing context=].
+
+  1. If |bc| is [=discard|discarded=], [=map/remove=] |referrerDoc|'s [=Document/prerendering browsing contexts map=][(|startingURL|, |referrerPolicy|)].
+
+     <p class="note">As with regular [=browsing context|browsing contexts=], The [=prerendering browsing context=] can be [=discard|discarded=] for any reason, for example if it becomes unresponsive, performs a restricted operation, or if the user-agent believes prerendering takes too much resources.
+
 </div>
 
 <div algorithm>
@@ -421,15 +426,6 @@ Every {{Document}} has an <dfn for="Document">activation start time</dfn>, which
       <p class="note">The order here is observable for [=browsing contexts=] that share an [=event loop=], but not for those in separate event loops.
 </div>
 
-<div algorithm>
-  To <dfn export for="prerendering browsing context">evict</dfn> a [=prerendering browsing context=] |bc| given an optional Null or {{Document}} |doc| (default ull):
-
-  1. [=Discard=] |bc|.
-
-  1. If |doc| is not null, then [=map/for each=] |key| -> |value| of |doc|'s [=Document/prerendering browsing contexts map=], if |value| is |bc|, then [=map/remove=] |doc|'s [=Document/prerendering browsing contexts map=][|key|].
-
-  User-agents may choose to [=prerendering browsing context/evict=] a [=prerendering browsing context=] at any time, e.g. to save resources for active pages.
-</div>
 <h3 id="creating-bcs-patch">Modifications to creating browsing contexts</h3>
 
 <div algorithm="create a new nested browsing context patch">
@@ -472,7 +468,7 @@ Patch the [=navigate=] algorithm to allow the [=prerendering browsing context/ac
     1. Return.
 </div>
 
-Patch the [=navigate=] algorithm to allow delaying or evicting of a cross-origin navigations in a [=prerendering browsing context=] as follows:
+Patch the [=navigate=] algorithm to allow delaying or discarding of a cross-origin navigations in a [=prerendering browsing context=] as follows:
 
 <div algorithm="navigate delay cross-origin patch">
   In [=navigate=], append the following steps after the cross-origin redirect check (currently step 13.1):
@@ -483,7 +479,7 @@ Patch the [=navigate=] algorithm to allow delaying or evicting of a cross-origin
 
   1. If |crossOrigin| is true and |browsingContext|'s [=top-level browsing context=] is a [=prerendering browsing context=], then wait until |browsingContext| is [=prerendering browsing context/activate|activated=].
 
-  User agents may choose to [=prerendering browsing context/evict=] a [=prerendering browsing context=] when its document or one of its iframes navigates to a cross-origin URL.
+  User agents may choose to [=discard=] a [=prerendering browsing context=] when its document or one of its iframes navigates to a cross-origin URL.
 </div>
 
 Navigation redirects can also [=prerendering browsing context/activate=] [=prerendering browsing contexts=]. This is defined in the [[#redirect-handling]] section.

--- a/prerendering.bs
+++ b/prerendering.bs
@@ -421,6 +421,15 @@ Every {{Document}} has an <dfn for="Document">activation start time</dfn>, which
       <p class="note">The order here is observable for [=browsing contexts=] that share an [=event loop=], but not for those in separate event loops.
 </div>
 
+<div algorithm>
+  To <dfn export for="prerendering browsing context">evict</dfn> a [=prerendering browsing context=] |bc| given an optional Null or {{Document}} |doc| (default ull):
+
+  1. [=Discard=] |bc|.
+
+  1. If |doc| is not null, then [=map/for each=] |key| -> |value| of |doc|'s [=Document/prerendering browsing contexts map=], if |value| is |bc|, then [=map/remove=] |doc|'s [=Document/prerendering browsing contexts map=][|key|].
+
+  User-agents may choose to [=prerendering browsing context/evict=] a [=prerendering browsing context=] at any time, e.g. to save resources for active pages.
+</div>
 <h3 id="creating-bcs-patch">Modifications to creating browsing contexts</h3>
 
 <div algorithm="create a new nested browsing context patch">
@@ -461,6 +470,20 @@ Patch the [=navigate=] algorithm to allow the [=prerendering browsing context/ac
     1. [=prerendering browsing context/Activate=] <var ignore>successorBC</var> in place of |browsingContext| given |historyHandling|.
 
     1. Return.
+</div>
+
+Patch the [=navigate=] algorithm to allow delaying or evicting of a cross-origin navigations in a [=prerendering browsing context=] as follows:
+
+<div algorithm="navigate delay cross-origin patch">
+  In [=navigate=], append the following steps after the cross-origin redirect check (currently step 13.1):
+
+  1. Let |crossOrigin| be |hasCrossOriginRedirects|.
+
+  1. f |bc|'s [=browsing context/container=] is not null, and |bc|'s [=browsing context/container=]'s [=node document=]'s	[=Document/origin=] is not [=same origin=] as |currentURL|'s [=url/origin=], then set |crossOrigin| to true.
+
+  1. If |crossOrigin| is true and |browsingContext|'s [=top-level browsing context=] is a [=prerendering browsing context=], then wait until |browsingContext| is [=prerendering browsing context/activate|activated=].
+
+  User agents may choose to [=prerendering browsing context/evict=] a [=prerendering browsing context=] when its document or one of its iframes navigates to a cross-origin URL.
 </div>
 
 Navigation redirects can also [=prerendering browsing context/activate=] [=prerendering browsing contexts=]. This is defined in the [[#redirect-handling]] section.

--- a/prerendering.bs
+++ b/prerendering.bs
@@ -479,7 +479,7 @@ Patch the [=navigate=] algorithm to allow delaying or evicting of a cross-origin
 
   1. Let |crossOrigin| be <var ignore>hasCrossOriginRedirects</var>.
 
-  1. f |bc|'s <a spec="HTML">container</a> is not null, and |bc|'s <a spec="HTML">container</a>'s [=node document=]'s	[=Document/origin=] is not [=same origin=] as <var ignore>currentURL</var>'s [=url/origin=], then set |crossOrigin| to true.
+  1. f |bc|'s <a spec="HTML">container</a> is not null, and |bc|'s <a spec="HTML">container</a>'s [=Node/node document=]'s	[=Document/origin=] is not [=same origin=] as <var ignore>currentURL</var>'s [=url/origin=], then set |crossOrigin| to true.
 
   1. If |crossOrigin| is true and |browsingContext|'s [=top-level browsing context=] is a [=prerendering browsing context=], then wait until |browsingContext| is [=prerendering browsing context/activate|activated=].
 

--- a/prerendering.bs
+++ b/prerendering.bs
@@ -27,6 +27,8 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
   type: dfn
     urlPrefix: browsers.html
       text: creating a new top-level browsing context; url: creating-a-new-top-level-browsing-context
+      for: browsing context
+        text: remove; url: bcg-remove;
     urlPrefix: history.html
       text: session history; url: session-history
     urlPrefix: browsing-the-web.html

--- a/prerendering.bs
+++ b/prerendering.bs
@@ -396,7 +396,6 @@ Every {{Document}} has an <dfn for="Document">activation start time</dfn>, which
   1. Let |request| be a new [=request=] whose [=request/URL=] is |startingURL| and [=request/referrer policy=] is |referrerPolicy|.
 
   1. [=Navigate=] |bc| to |request| with the [=source browsing context=] set to |referrerDoc|'s [=Document/browsing context=].
-
 </div>
 
 <div algorithm>
@@ -509,7 +508,7 @@ Patch the [=navigate=] algorithm to allow the [=prerendering browsing context/ac
 Patch the [=process a navigate fetch=] algorithm to allow delaying or discarding of cross-origin navigations in a [=prerendering browsing context=] as follows:
 
 <div algorithm="navigate delay cross-origin patch">
-  In [=navigate=], append the following steps after the cross-origin redirect check (currently step 13.1):
+  In [=process a navigate fetch=], append the following steps after the cross-origin redirect check (currently step 13.1):
 
   1. Let |crossOrigin| be <var ignore>hasCrossOriginRedirects</var>.
 


### PR DESCRIPTION
- Add text on what happens when a prerendering context is discarded
- Always delay cross-origin navigations, and allow evicting at that point (though it's allowed at any point)