### PR TITLE
Delay speech-synthesis functions

### DIFF
--- a/prerendering.bs
+++ b/prerendering.bs
@@ -157,7 +157,7 @@ spec: screen-capture; urlPrefix: https://w3c.github.io/mediacapture-screen-share
 spec: audio-output; urlPrefix: https://w3c.github.io/mediacapture-output/
   type: method; for: MediaDevices
     text: selectAudioOutput(); url: dom-mediadevices-selectaudiooutput
-spec: speech; urlPrefix: https://wicg.github.io/speech-api/
+spec: speech-api; urlPrefix: https://wicg.github.io/speech-api/
   type: interface
     text: SpeechSynthesis; url: speechsynthesis
   type: method; for: SpeechSynthesis

--- a/prerendering.bs
+++ b/prerendering.bs
@@ -823,7 +823,7 @@ Add {{[DelayWhilePrerendering]}} to {{CredentialsContainer/get()}}, {{Credential
 
 Add {{[DelayWhilePrerendering]}} to	{{SpeechSynthesis/speak(utterance)}}, {{SpeechSynthesis/cancel()}},	{{SpeechSynthesis/pause()}}, and {{SpeechSynthesis/resume()}}.
 
-Add {{[DelayWhilePrerendering]}} to{{SpeechRecognition/start()}}, {{SpeechRecognition/stop()}} and {{SpeechRecognition/abort()}}.
+Add {{[DelayWhilePrerendering]}} to {{SpeechRecognition/start()}}, {{SpeechRecognition/stop()}}, and {{SpeechRecognition/abort()}}.
 
 <h3 id="implicitly-restricted">Implicitly restricted APIs</h3>
 

--- a/prerendering.bs
+++ b/prerendering.bs
@@ -157,7 +157,29 @@ spec: screen-capture; urlPrefix: https://w3c.github.io/mediacapture-screen-share
 spec: audio-output; urlPrefix: https://w3c.github.io/mediacapture-output/
   type: method; for: MediaDevices
     text: selectAudioOutput(); url: dom-mediadevices-selectaudiooutput
+spec: speech; urlPrefix: https://wicg.github.io/speech-api/
+  type: interface
+    text: SpeechSynthesis; url: speechsynthesis
+  type: method; for: SpeechSynthesis
+    text: speak(utterance); url: dom-speechsynthesis-speak
+  type: method; for: SpeechSynthesis
+    text: cancel(); url: dom-speechsynthesis-cancel
+  type: method; for: SpeechSynthesis
+    text: pause(); url: dom-speechsynthesis-pause
+  type: method; for: SpeechSynthesis
+    text: Resume(); url: dom-speechsynthesis-resume
+  type: method; for: SpeechSynthesis
+    text: getVoices(); url: dom-speechsynthesis-getvoices
+  type: interface
+    text: SpeechRecognition; url: speechrecognition
+  type: method; for: SpeechRecognition
+    text: start(); url: dom-speechrecognition-start
+  type: method; for: SpeechRecognition
+    text: cancel(); url: dom-speechrecognition-cancel
+  type: method; for: SpeechRecognition
+    text: abort(); url: dom-speechrecognition-abort
 
+Web Speech API. cg-draft. URL: 
 </pre>
 <pre class="biblio">
 {

--- a/prerendering.bs
+++ b/prerendering.bs
@@ -175,7 +175,7 @@ spec: speech-api; urlPrefix: https://wicg.github.io/speech-api/
   type: method; for: SpeechRecognition
     text: start(); url: dom-speechrecognition-start
   type: method; for: SpeechRecognition
-    text: cancel(); url: dom-speechrecognition-cancel
+    text: stop(); url: dom-speechrecognition-stop
   type: method; for: SpeechRecognition
     text: abort(); url: dom-speechrecognition-abort
 </pre>

--- a/prerendering.bs
+++ b/prerendering.bs
@@ -162,13 +162,9 @@ spec: speech-api; urlPrefix: https://wicg.github.io/speech-api/
     text: SpeechSynthesis; url: speechsynthesis
   type: method; for: SpeechSynthesis
     text: speak(utterance); url: dom-speechsynthesis-speak
-  type: method; for: SpeechSynthesis
     text: cancel(); url: dom-speechsynthesis-cancel
-  type: method; for: SpeechSynthesis
     text: pause(); url: dom-speechsynthesis-pause
-  type: method; for: SpeechSynthesis
     text: resume(); url: dom-speechsynthesis-resume
-  type: method; for: SpeechSynthesis
     text: getVoices(); url: dom-speechsynthesis-getvoices
   type: interface
     text: SpeechRecognition; url: speechrecognition

--- a/prerendering.bs
+++ b/prerendering.bs
@@ -807,7 +807,9 @@ Add {{[DelayWhilePrerendering]}} to {{CredentialsContainer/get()}}, {{Credential
 
 <h4 id="web-speech-patch">Web Speech API</h4>
 
-Add {{[DelayWhilePrerendering]}} to	{{SpeechSynthesis/speak}}, {{SpeechSynthesis/cancel}},	{{SpeechSynthesis/pause}}, and {{SpeechSynthesis/resume}}. 
+Add {{[DelayWhilePrerendering]}} to	{{SpeechSynthesis/speak(utterance)}}, {{SpeechSynthesis/cancel()}},	{{SpeechSynthesis/pause()}}, and {{SpeechSynthesis/resume()}}. 
+
+Add {{[DelayWhilePrerendering]}} to{{SpeechRecognition/start()}}, {{SpeechRecognition/stop()}} and {{SpeechRecognition/abort()}}. 
 
 <h3 id="implicitly-restricted">Implicitly restricted APIs</h3>
 

--- a/prerendering.bs
+++ b/prerendering.bs
@@ -805,6 +805,10 @@ Add {{[DelayWhilePrerendering]}} to {{XRSystem/requestSession()}}.
 
 Add {{[DelayWhilePrerendering]}} to {{CredentialsContainer/get()}}, {{CredentialsContainer/store()}}, and {{CredentialsContainer/create()}}. 
 
+<h4 id="web-speech-patch">Web Speech API</h4>
+
+Add {{[DelayWhilePrerendering]}} to	{{SpeechSynthesis/speak}}, {{SpeechSynthesis/cancel}},	{{SpeechSynthesis/pause}}, and {{SpeechSynthesis/resume}}. 
+
 <h3 id="implicitly-restricted">Implicitly restricted APIs</h3>
 
 Some APIs do not need modifications because they will automatically fail or no-op without a property that a [=prerendering browsing context=], its [=browsing context/active window=], or its [=active document=] will never have. These properties include:

--- a/prerendering.bs
+++ b/prerendering.bs
@@ -174,9 +174,7 @@ spec: speech-api; urlPrefix: https://wicg.github.io/speech-api/
     text: SpeechRecognition; url: speechrecognition
   type: method; for: SpeechRecognition
     text: start(); url: dom-speechrecognition-start
-  type: method; for: SpeechRecognition
     text: stop(); url: dom-speechrecognition-stop
-  type: method; for: SpeechRecognition
     text: abort(); url: dom-speechrecognition-abort
 </pre>
 <pre class="biblio">

--- a/prerendering.bs
+++ b/prerendering.bs
@@ -827,9 +827,9 @@ Add {{[DelayWhilePrerendering]}} to {{CredentialsContainer/get()}}, {{Credential
 
 <h4 id="web-speech-patch">Web Speech API</h4>
 
-Add {{[DelayWhilePrerendering]}} to	{{SpeechSynthesis/speak(utterance)}}, {{SpeechSynthesis/cancel()}},	{{SpeechSynthesis/pause()}}, and {{SpeechSynthesis/resume()}}. 
+Add {{[DelayWhilePrerendering]}} to	{{SpeechSynthesis/speak(utterance)}}, {{SpeechSynthesis/cancel()}},	{{SpeechSynthesis/pause()}}, and {{SpeechSynthesis/resume()}}.
 
-Add {{[DelayWhilePrerendering]}} to{{SpeechRecognition/start()}}, {{SpeechRecognition/stop()}} and {{SpeechRecognition/abort()}}. 
+Add {{[DelayWhilePrerendering]}} to{{SpeechRecognition/start()}}, {{SpeechRecognition/stop()}} and {{SpeechRecognition/abort()}}.
 
 <h3 id="implicitly-restricted">Implicitly restricted APIs</h3>
 

--- a/prerendering.bs
+++ b/prerendering.bs
@@ -167,7 +167,7 @@ spec: speech-api; urlPrefix: https://wicg.github.io/speech-api/
   type: method; for: SpeechSynthesis
     text: pause(); url: dom-speechsynthesis-pause
   type: method; for: SpeechSynthesis
-    text: Resume(); url: dom-speechsynthesis-resume
+    text: resume(); url: dom-speechsynthesis-resume
   type: method; for: SpeechSynthesis
     text: getVoices(); url: dom-speechsynthesis-getvoices
   type: interface

--- a/prerendering.bs
+++ b/prerendering.bs
@@ -178,8 +178,6 @@ spec: speech; urlPrefix: https://wicg.github.io/speech-api/
     text: cancel(); url: dom-speechrecognition-cancel
   type: method; for: SpeechRecognition
     text: abort(); url: dom-speechrecognition-abort
-
-Web Speech API. cg-draft. URL: 
 </pre>
 <pre class="biblio">
 {


### PR DESCRIPTION
See https://wicg.github.io/speech-api/#speechrecognition and https://wicg.github.io/speech-api/#tts-section.
Note that that API doesn't currently handle anything to do with document focus, which should be fixed separately.