### PR TITLE
Defer new SW registration from a prerendered page until it's activated

### DIFF
--- a/prerendering.bs
+++ b/prerendering.bs
@@ -173,7 +173,8 @@ spec: speech-api; urlPrefix: https://wicg.github.io/speech-api/
     text: stop(); url: dom-speechrecognition-stop
     text: abort(); url: dom-speechrecognition-abort
 spec: service-workers; urlPrefix: https://w3c.github.io/ServiceWorker/
-  text: Service worker installation algorithm; url: installation-algorithm 
+  type: dfn
+    text: Service worker installation algorithm; url: installation-algorithm
 </pre>
 <pre class="biblio">
 {

--- a/prerendering.bs
+++ b/prerendering.bs
@@ -668,7 +668,7 @@ The {{[DelayWhilePrerendering]}} extended attribute must take no arguments, and 
   1. Otherwise, return the result of running the originally-specified steps for this operation, with the same [=this=] and arguments.
 </div>
 
-<h4 id="service-workerד">Service Workers</h3>
+<h4 id="patch-service-workers">Service Workers</h3>
 
 Add {{[DelayWhilePrerendering]}} to {{ServiceWorkerRegistration/update()}}, {{ServiceWorkerRegistration/unregister()}}, and {{ServiceWorkerContainer/register(scriptURL, options)}}.
 

--- a/prerendering.bs
+++ b/prerendering.bs
@@ -173,12 +173,15 @@ spec: speech-api; urlPrefix: https://wicg.github.io/speech-api/
     text: stop(); url: dom-speechrecognition-stop
     text: abort(); url: dom-speechrecognition-abort
 spec: service-workers; urlPrefix: https://w3c.github.io/ServiceWorker/
-  type: dfn
-    text: Register Service Worker; url: register
-    text: job; url: dfn-job
-    text: window client; url: dfn-window-client
-  type: dfn; for: job
-    text: client; url: dfn-job-client
+  type: interface
+    text: ServiceWorkerRegistration; url: serviceworkerregistration-interface
+  type: method; for: ServiceWorkerRegistration
+    text: update(); url: dom-serviceworkerregistration-update
+    text: unregister(); url: dom-serviceworkerregistration-unregister
+  type: interface
+    text: ServiceWorkerContainer; url: serviceworkercontainer-interface
+  type: method; for: ServiceWorkerRegistration
+    text: register(scriptURL, options); url: dom-serviceworkercontainer-register
 </pre>
 <pre class="biblio">
 {
@@ -641,17 +644,6 @@ Modify the <a spec=HTML>download the hyperlink</a> algorithm to ensure that down
   1. If [=this=]'s [=Window/browsing context=] is a [=prerendering browsing context=], then return.
 </div>
 
-<h3 id="service-worker-registration">Service Worker Registration</h3>
-
-To prevent a case where a prerendering document installs a new service-worker that affects active documents or creates notifications, discard the [=prerendering browsing context=] when it tries to register a [=service worker=] that wasn't previously registered:
-
-Prepend the following to the [=Register Service Worker=] algorithm:
-
-1. If <var ignore>job</var>'s [=job/client=] is a [=window client=], then:
-    1. Let |bc| be <var ignore>job</var>'s [=job/client=]'s [=environment settings object/global object=]'s [=global object=]'s [=/browsing context=].
-    
-    1. If |bc| is a [=prerendering browsing context=], then wait until |bc| is [=prerendering browsing context/activated=].
-
 <h3 id="delay-async-apis">Delaying async API results</h3>
 
 Many specifications need to be patched so that, if a given algorithm invoked in a [=prerendering browsing context=], most of its work is deferred until the browsing context is [=prerendering browsing context/activated=]. This is tricky to do uniformly, as many of these specifications do not have great hygeine around <a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-loop-for-spec-authors">using the event loop</a>. Nevertheless, the following sections give our best attempt.
@@ -675,6 +667,12 @@ The {{[DelayWhilePrerendering]}} extended attribute must take no arguments, and 
     1. If this operation's <a spec="WEBIDL">return type</a> is a <a spec="WEBIDL">promise type</a>, then return |promise|.
   1. Otherwise, return the result of running the originally-specified steps for this operation, with the same [=this=] and arguments.
 </div>
+
+<h4 id="service-workerד">Service Workers</h3>
+
+Add {{DelayWhilePrerendering}} to {{ServiceWorkerRegistration/update()}}, {{ServiceWorkerRegistration/unregister()}}, and {{ServiceWorkerContainer/register(scriptURL, options)}}.
+
+<p class="note">This allows prerendered page to take advantage of existing service workers, but not have any effect on the state of service worker registrations.</p>
 
 <h4 id="patch-geolocation">Geolocation API</h4>
 

--- a/prerendering.bs
+++ b/prerendering.bs
@@ -595,6 +595,16 @@ The <dfn attribute for="PerformanceNavigationTiming">activationStart</dfn> gette
 
 <p class="note">This value is 0 in cross-origin prerenders.
 
+<h3 id="service-worker-extension">Extension to [=service worker=] installation</h3>
+
+To prevent a case where a prerendering document installs a new service-worker that affects active documents or creates notifications:
+
+Add the following to the [=Install Service Worker=] algorithm as, after the assigning of |settingsObjects| (currently step 8):
+
+1. For each |settingsObject| of |settingsObjects|, run the following steps in parallel:
+    1. if |settingsObject|'s [=environment settings object/global object=] is a {{Window}} object, and |settingsObject|'s [=environment settings object/global object=]'s [=/browsing context=] is a [=prerendering browsing context=], then wait until |settingsObject|'s [=environment settings object/global object=]'s [=/browsing context=] is [=prerendering browsing context/activate|activated=].
+    1. Abort these steps.
+
 <h2 id="nonsense-behaviors">Preventing nonsensical behaviors</h2>
 
 Some behaviors might make sense in most [=top-level browsing contexts=], but do not make sense in [=prerendering browsing contexts=]. This section enumerates specification patches to enforce such restrictions.

--- a/prerendering.bs
+++ b/prerendering.bs
@@ -172,6 +172,8 @@ spec: speech-api; urlPrefix: https://wicg.github.io/speech-api/
     text: start(); url: dom-speechrecognition-start
     text: stop(); url: dom-speechrecognition-stop
     text: abort(); url: dom-speechrecognition-abort
+spec: service-workers; urlPrefix: https://w3c.github.io/ServiceWorker/
+  text: Service worker installation algorithm; url: installation-algorithm 
 </pre>
 <pre class="biblio">
 {
@@ -599,7 +601,7 @@ The <dfn attribute for="PerformanceNavigationTiming">activationStart</dfn> gette
 
 To prevent a case where a prerendering document installs a new service-worker that affects active documents or creates notifications:
 
-Add the following to the [=Install Service Worker=] algorithm as, after the assigning of |settingsObjects| (currently step 8):
+Add the following to the [=Service worker installation algorithm=] algorithm as, after the assigning of |settingsObjects| (currently step 8):
 
 1. For each |settingsObject| of |settingsObjects|, run the following steps in parallel:
     1. if |settingsObject|'s [=environment settings object/global object=] is a {{Window}} object, and |settingsObject|'s [=environment settings object/global object=]'s [=/browsing context=] is a [=prerendering browsing context=], then wait until |settingsObject|'s [=environment settings object/global object=]'s [=/browsing context=] is [=prerendering browsing context/activate|activated=].
@@ -732,8 +734,6 @@ Add {{[DelayWhilePrerendering]}} to {{Notification/requestPermission()}}.
 
   1. Otherwise, <a spec="NOTIFICATIONS">get the notifications permission state</a> and return it.
 </div>
-
-TODO: what about the service worker API? Depends on what we're doing for service workers in prerendering BCs...
 
 <h4 id="patch-midi">Web MIDI API</h4>
 

--- a/prerendering.bs
+++ b/prerendering.bs
@@ -670,7 +670,7 @@ The {{[DelayWhilePrerendering]}} extended attribute must take no arguments, and 
 
 <h4 id="service-workerד">Service Workers</h3>
 
-Add {{DelayWhilePrerendering}} to {{ServiceWorkerRegistration/update()}}, {{ServiceWorkerRegistration/unregister()}}, and {{ServiceWorkerContainer/register(scriptURL, options)}}.
+Add {{[DelayWhilePrerendering]}} to {{ServiceWorkerRegistration/update()}}, {{ServiceWorkerRegistration/unregister()}}, and {{ServiceWorkerContainer/register(scriptURL, options)}}.
 
 <p class="note">This allows prerendered page to take advantage of existing service workers, but not have any effect on the state of service worker registrations.</p>
 

--- a/prerendering.bs
+++ b/prerendering.bs
@@ -650,7 +650,7 @@ Prepend the following to the [=Register Service Worker=] algorithm:
 1. If <var ignore>job</var>'s [=job/client=] is a [=window client=], then:
     1. Let |bc| be <var ignore>job</var>'s [=job/client=]'s [=environment settings object/global object=]'s [=global object=]'s [=/browsing context=].
     
-    1. If |bc| is a [=prerendering browsing context=], then [=discard=] |bc|.
+    1. If |bc| is a [=prerendering browsing context=], then wait until |bc| is [=prerendering browsing context/activated=].
 
 <h3 id="delay-async-apis">Delaying async API results</h3>
 

--- a/prerendering.bs
+++ b/prerendering.bs
@@ -174,7 +174,10 @@ spec: speech-api; urlPrefix: https://wicg.github.io/speech-api/
     text: abort(); url: dom-speechrecognition-abort
 spec: service-workers; urlPrefix: https://w3c.github.io/ServiceWorker/
   type: dfn
-    text: Service worker installation algorithm; url: installation-algorithm
+    text: Register Service Worker; url: register
+    text: job; url: dfn-job
+  type: dfn; for: job
+    text: client; url: dfn-job-client
 </pre>
 <pre class="biblio">
 {
@@ -598,16 +601,6 @@ The <dfn attribute for="PerformanceNavigationTiming">activationStart</dfn> gette
 
 <p class="note">This value is 0 in cross-origin prerenders.
 
-<h3 id="service-worker-extension">Extension to [=service worker=] installation</h3>
-
-To prevent a case where a prerendering document installs a new service-worker that affects active documents or creates notifications:
-
-Add the following to the [=Service worker installation algorithm=] algorithm as, after the assigning of |settingsObjects| (currently step 8):
-
-1. For each |settingsObject| of |settingsObjects|, run the following steps in parallel:
-    1. if |settingsObject|'s [=environment settings object/global object=] is a {{Window}} object, and |settingsObject|'s [=environment settings object/global object=]'s [=/browsing context=] is a [=prerendering browsing context=], then wait until |settingsObject|'s [=environment settings object/global object=]'s [=/browsing context=] is [=prerendering browsing context/activate|activated=].
-    1. Abort these steps.
-
 <h2 id="nonsense-behaviors">Preventing nonsensical behaviors</h2>
 
 Some behaviors might make sense in most [=top-level browsing contexts=], but do not make sense in [=prerendering browsing contexts=]. This section enumerates specification patches to enforce such restrictions.
@@ -646,6 +639,17 @@ Modify the <a spec=HTML>download the hyperlink</a> algorithm to ensure that down
 
   1. If [=this=]'s [=Window/browsing context=] is a [=prerendering browsing context=], then return.
 </div>
+
+<h3 id="service-worker-registration">Service Worker Registration</h3>
+
+To prevent a case where a prerendering document installs a new service-worker that affects active documents or creates notifications, discard the [=prerendering browsing context=] when it tries to register a [=service worker=] that wasn't previously registered:
+
+Prepend the following to the [=Register Service Worker=] algorithm:
+
+1. If <var ignore>job</var>'s [=job/client=] is a [=window client=], then:
+    1. Let |bc| be <var ignore>job</var>'s [=job/client=]'s [=environment settings object/global object=]'s [=global object=]'s [=/browsing context=].
+    
+    1. If |bc| is a [=prerendering browsing context=], then [=discard=] |bc|.
 
 <h3 id="delay-async-apis">Delaying async API results</h3>
 

--- a/prerendering.bs
+++ b/prerendering.bs
@@ -176,6 +176,7 @@ spec: service-workers; urlPrefix: https://w3c.github.io/ServiceWorker/
   type: dfn
     text: Register Service Worker; url: register
     text: job; url: dfn-job
+    text: window client; url: dfn-window-client
   type: dfn; for: job
     text: client; url: dfn-job-client
 </pre>


### PR DESCRIPTION
This prevents nonsensical behavior such as a prerendering context creating a service-worker that can create notifications or cache in a way that affects non-prerendering contexts.

An attempt at https://github.com/WICG/nav-speculation/issues/44