### PR TITLE
Delay BroadcastChannel and ServiceWorker postMessage

### DIFF
--- a/prerendering.bs
+++ b/prerendering.bs
@@ -188,8 +188,13 @@ spec: service-workers; urlPrefix: https://w3c.github.io/ServiceWorker/
     text: unregister(); url: dom-serviceworkerregistration-unregister
   type: interface
     text: ServiceWorkerContainer; url: serviceworkercontainer-interface
-  type: method; for: ServiceWorkerRegistration
+  type: method; for: ServiceWorkerContainer
     text: register(scriptURL, options); url: dom-serviceworkercontainer-register
+  type: interface
+    text: ServieWorker; url: serviceworker-interface
+  type: method: for: ServiceWorker
+    text: postMessage(message, transfer); url: dom-serviceworker-postmessage
+    text: postMessage(message, options); url: service-worker-postmessage-options
 </pre>
 <pre class="biblio">
 {
@@ -713,7 +718,7 @@ The {{[DelayWhilePrerendering]}} extended attribute must take no arguments, and 
 
 <h4 id="patch-service-workers">Service Workers</h3>
 
-Add {{[DelayWhilePrerendering]}} to {{ServiceWorkerRegistration/update()}}, {{ServiceWorkerRegistration/unregister()}}, and {{ServiceWorkerContainer/register(scriptURL, options)}}.
+Add {{[DelayWhilePrerendering]}} to {{ServiceWorkerRegistration/update()}}, {{ServiceWorkerRegistration/unregister()}}, {{ServiceWorkerContainer/register(scriptURL, options)}}, {{ServiceWorker/postMessage(message, transfer)}}, and {{ServiceWorker/ postMessage(message, options)}}.
 
 <p class="note">This allows prerendered page to take advantage of existing service workers, but not have any effect on the state of service worker registrations.</p>
 

--- a/prerendering.bs
+++ b/prerendering.bs
@@ -51,6 +51,8 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
     urlPrefix: urls-and-fetching.html
       text: parse a URL; url: parse-a-url
       text: resulting URL record
+    urlPrefix: web-messaging.html
+      text: BroadcastChannel; url: broadcastchannel
     urlPrefix: webappapis.html
       text: script; url: concept-script
     urlPrefix: workers.html
@@ -714,6 +716,10 @@ The {{[DelayWhilePrerendering]}} extended attribute must take no arguments, and 
 Add {{[DelayWhilePrerendering]}} to {{ServiceWorkerRegistration/update()}}, {{ServiceWorkerRegistration/unregister()}}, and {{ServiceWorkerContainer/register(scriptURL, options)}}.
 
 <p class="note">This allows prerendered page to take advantage of existing service workers, but not have any effect on the state of service worker registrations.</p>
+
+<h4 id="patch-broadcast-channel">BroadcastChannel</h4>
+
+Add {{[DelayWhilePrerendering]}} to {{BroadcastChannel/postMessage()}}.
 
 <h4 id="patch-geolocation">Geolocation API</h4>
 

--- a/prerendering.bs
+++ b/prerendering.bs
@@ -191,7 +191,7 @@ spec: service-workers; urlPrefix: https://w3c.github.io/ServiceWorker/
   type: method; for: ServiceWorkerContainer
     text: register(scriptURL, options); url: dom-serviceworkercontainer-register
   type: interface
-    text: ServieWorker; url: serviceworker-interface
+    text: ServiceWorker; url: serviceworker-interface
   type: method: for: ServiceWorker
     text: postMessage(message, transfer); url: dom-serviceworker-postmessage
     text: postMessage(message, options); url: service-worker-postmessage-options


### PR DESCRIPTION
Closes https://github.com/WICG/nav-speculation/issues/141
Delay posting messages to broadcast channels and service workers, to avoid nonsensical behavior such as prerendering tabs notifying other tabs that they are active.