### PR TITLE
Wait until all navigations have matured before activating

### DIFF
--- a/prerendering.bs
+++ b/prerendering.bs
@@ -496,25 +496,19 @@ Every {{Document}} has an <dfn for="Document">activation start time</dfn>, which
 Patch the [=navigate=] algorithm to allow the [=prerendering browsing context/activate|activation=] of a [=prerendering browsing context=] in place of a normal navigation as follows:
 
 <div algorithm="navigate activate patch">
-  In [=navigate=], append the following steps after the fragment navigation handling (currently step 6):
+  In [=navigate=], append the following steps after the fragment navigation handling (currently step 8):
 
   1. If |resource| is a [=request=] and we [=can activate a prerender=] given |browsingContext|, |historyHandling|, <var ignore>navigationType</var>, and |resource|, then:
 
-    1. [=prerendering browsing context/Activate=] <var ignore>successorBC</var> in place of |browsingContext| given |historyHandling|.
+    1. Let |successorBC| be |browsingContext|'s [=active document=]'s [=Document/prerendering browsing contexts map=][(|resource|'s [=request/URL=], |resource|'s [=request/referrer policy=])].
 
-    1. Return.
-</div>
+    1. Wait until all navigation attempts of |successorBC| have been [=mature|matured=].
 
-Patch the [=process a navigate fetch=] algorithm to allow delaying or discarding of cross-origin navigations in a [=prerendering browsing context=] as follows:
+    1. If |successorBC| has not been [=discard|discarded=], then:
 
-<div algorithm="navigate delay cross-origin patch">
-  In [=process a navigate fetch=], append the following steps after the cross-origin redirect check (currently step 13.1):
+      1. [=prerendering browsing context/Activate=] |successorBC| in place of |browsingContext| given |historyHandling|.
 
-  1. Let |crossOrigin| be <var ignore>hasCrossOriginRedirects</var>.
-
-  1. If |bc|'s <a spec="HTML">container</a> is not null, and |bc|'s <a spec="HTML">container</a>'s [=Node/node document=]'s	[=Document/origin=] is not [=same origin=] with <var ignore>currentURL</var>'s [=url/origin=], then set |crossOrigin| to true.
-
-  1. If |crossOrigin| is true and |bc|'s [=top-level browsing context=] is a [=prerendering browsing context=], then the user agent must either wait to continue this algorithm until |bc| is [=prerendering browsing context/activate|activated=], or [=discard=] |bc|'s [=top-level browsing context=].
+      1. Return.
 </div>
 
 Navigation redirects can also [=prerendering browsing context/activate=] [=prerendering browsing contexts=]. This is defined in the [[#redirect-handling]] section.
@@ -547,6 +541,20 @@ Patch the [=process a navigate fetch=] algorithm like so:
       1. [=Assert=]: |response|'s [=response/location URL=] is a [=URL=] whose [=url/scheme=] is a [=HTTP(S) scheme=].
 
       1. Set |response| to a [=network error=] and [=iteration/break=].
+</div>
+
+<h3 id="delay-crossorigin">Delaying crossorigin navigations</h3>
+
+Patch the [=process a navigate fetch=] algorithm to allow delaying or discarding of cross-origin navigations in a [=prerendering browsing context=] as follows:
+
+<div algorithm="navigate delay cross-origin patch">
+  In [=process a navigate fetch=], append the following steps after the cross-origin redirect check (currently step 13.1):
+
+  1. Let |crossOrigin| be <var ignore>hasCrossOriginRedirects</var>.
+
+  1. If |bc|'s <a spec="HTML">container</a> is not null, and |bc|'s <a spec="HTML">container</a>'s [=Node/node document=]'s	[=Document/origin=] is not [=same origin=] with <var ignore>currentURL</var>'s [=url/origin=], then set |crossOrigin| to true.
+
+  1. If |crossOrigin| is true and |bc|'s [=top-level browsing context=] is a [=prerendering browsing context=], then the user agent must either wait to continue this algorithm until |bc| is [=prerendering browsing context/activate|activated=], or [=discard=] |bc|'s [=top-level browsing context=].
 </div>
 
 <h3 id="always-replacement">Maintaining a trivial session history</h3>

--- a/prerendering.bs
+++ b/prerendering.bs
@@ -502,7 +502,7 @@ Patch the [=navigate=] algorithm to allow the [=prerendering browsing context/ac
 
     1. Let |successorBC| be |browsingContext|'s [=active document=]'s [=Document/prerendering browsing contexts map=][(|resource|'s [=request/URL=], |resource|'s [=request/referrer policy=])].
 
-    1. Wait until all navigation attempts of |successorBC| have been [=mature|matured=].
+    1. Wait until all navigation attempts of |successorBC| have been [=navigate/mature|matured=].
 
     1. If |successorBC| has not been [=discard|discarded=], then:
 


### PR DESCRIPTION
This allows restarting a navigation if it has failed due to the server rejecting the prerender
Closes https://github.com/WICG/nav-speculation/issues/145