### PR TITLE
Perform navigate-to CSP checks when activating

### DIFF
--- a/prerendering.bs
+++ b/prerendering.bs
@@ -403,9 +403,7 @@ Every {{Document}} has an <dfn for="Document">activation start time</dfn>, which
 
      <p class="note">As with regular [=browsing contexts=], the [=prerendering browsing context=] can be [=discarded=] for any reason, for example if it becomes unresponsive, performs a restricted operation, or if the user agent believes prerendering takes too much resources.
 
-  1. Let |request| be a new [=request=] whose [=request/URL=] is |startingURL|, [=request/referrer policy=] is |referrerPolicy|, and [=request/policy container=] is |referrerDoc|'s [=Document/policy container=], [=clone a policy container|cloned=].
-
-     <p class="note">The [=policy container=] is cloned to avoid a situation where changes in [=Content Security Policy=] affect a prerender that had already started.
+  1. Let |request| be a new [=request=] whose [=request/URL=] is |startingURL|, and [=request/referrer policy=] is |referrerPolicy|.
 
   1. [=Navigate=] |bc| to |request| with the [=source browsing context=] set to |referrerDoc|'s [=Document/browsing context=].
 </div>

--- a/prerendering.bs
+++ b/prerendering.bs
@@ -403,7 +403,7 @@ Every {{Document}} has an <dfn for="Document">activation start time</dfn>, which
 
      <p class="note">As with regular [=browsing contexts=], the [=prerendering browsing context=] can be [=discarded=] for any reason, for example if it becomes unresponsive, performs a restricted operation, or if the user agent believes prerendering takes too much resources.
 
-  1. Let |request| be a new [=request=] whose [=request/URL=] is |startingURL|, and [=request/referrer policy=] is |referrerPolicy|.
+  1. Let |request| be a new [=request=] whose [=request/URL=] is |startingURL| and [=request/referrer policy=] is |referrerPolicy|.
 
   1. [=Navigate=] |bc| to |request| with the [=source browsing context=] set to |referrerDoc|'s [=Document/browsing context=].
 </div>

--- a/prerendering.bs
+++ b/prerendering.bs
@@ -403,7 +403,9 @@ Every {{Document}} has an <dfn for="Document">activation start time</dfn>, which
 
      <p class="note">As with regular [=browsing contexts=], the [=prerendering browsing context=] can be [=discarded=] for any reason, for example if it becomes unresponsive, performs a restricted operation, or if the user agent believes prerendering takes too much resources.
 
-  1. Let |request| be a new [=request=] whose [=request/URL=] is |startingURL| and [=request/referrer policy=] is |referrerPolicy|.
+  1. Let |request| be a new [=request=] whose [=request/URL=] is |startingURL|, [=request/referrer policy=] is |referrerPolicy|, and [=request/policy container=] is |referrerDoc|'s [=Document/policy container=], [=clone a policy container|cloned=].
+
+     <p class="note">The [=policy container=] is cloned to avoid a situation where changes in [=Content Security Policy=] affect a prerender that had already started.
 
   1. [=Navigate=] |bc| to |request| with the [=source browsing context=] set to |referrerDoc|'s [=Document/browsing context=].
 </div>
@@ -498,6 +500,9 @@ Every {{Document}} has an <dfn for="Document">activation start time</dfn>, which
       * |navigationType| is "`other`"
       * |request|'s [=request/method=] is \``GET`\`
       * |browsingContext|'s [=active document=]'s [=Document/prerendering browsing contexts map=][(|request|'s [=request/URL=], |request|'s [=request/referrer policy=])] [=map/exists=] and is not [=prerendering browsing context/empty=]
+      * The result of calling [=should navigation request of type be blocked by content security policy?=] given |request| and <var ignore>navigationType</var> is "`Allowed`".
+
+        <p class="note">There is no need for an additional CSP check for the response, see [=navigate-to=].
 
   1. Otherwise, return false.
 


### PR DESCRIPTION
- When prerendering, the referring doc's policy container should be used to ensure its `navigate-to` is respected
- When activating, an additional `navigate-to` check should be made, in case it had changed in the meantime
  (e.g. by adding a `<meta http-equiv="Content-Security-Policy">` element dynamically)

Closes #43
