### PR TITLE
Update origin trial period for Prerenderer

### DIFF
--- a/same-origin-chrome-origin-trial.md
+++ b/same-origin-chrome-origin-trial.md
@@ -6,7 +6,7 @@ Google Chrome offers an [origin trial](https://github.com/GoogleChrome/OriginTri
 
 It is recommended to first read the feature's [explainer](same-origin-explainer.md). This document complements the explainer with information specific to the origin trial, such as quirks and limitations of Chrome's implementation today.
 
-The origin trial is scheduled to be available in Chrome 94 through Chrome 98, approximately September 2021 to Februrary 2022.
+The origin trial is scheduled to be available in Chrome 94 through Chrome 102, approximately September 2021 to Jun 2022.
 
 The origin trial is only supported on **Chrome for Android**. However, the feature can be experimented with on any platform by enabling the `"Prerender2"` in `chrome://flags` for local development.
 


### PR DESCRIPTION
I see the origin trial is still available. https://developer.chrome.com/origintrials/#/view_trial/1325184190353768449