### PR TITLE
Specify that prefetches are aborted when no speculation candidate continues to authorize them.

### DIFF
--- a/prefetch.bs
+++ b/prefetch.bs
@@ -434,10 +434,10 @@ These algorithms are based on [=process a navigate fetch=].
     1. Let (|response|, |locationURL|) be the result of [=performing a common navigational fetch=] given |request|, "`other`", |browsingContext|, null, an empty algorithm, |shouldBlockNavigationRequest|, and |shouldBlockNavigationResponse|, and |prefetchRecord|'s [=prefetch record/fetch controller=].
     1. If |locationURL| is failure or a [=URL=] whose [=url/scheme=] is not an [=HTTP(S) scheme=], then set |response| to a [=network error=].
     1. TODO: navigate-to, frame-src, XFO enforcement should probably be left to navigation, but what about Content-Disposition?
-    1. If |response| is a [=network error=], then [=prefetch record/cancel and discard=] |prefetchRecord| and return.
+    1. If |response| is a [=network error=], then [=prefetch record/cancel and discard=] |prefetchRecord| given |document|, and return.
     1. [=Assert=]: |response| is [=exchange record/response=] the last element of |prefetchRecord|'s [=prefetch record/redirect chain=].
-    1. If |response| does not [=support prefetch=], then [=prefetch record/cancel and discard=] |prefetchRecord| and return.
-    1. [=prefetch record/Complete=] |prefetchRecord|.
+    1. If |response| does not [=support prefetch=], then [=prefetch record/cancel and discard=] |prefetchRecord| given |document|, and return.
+    1. [=prefetch record/Complete=] |prefetchRecord| given |document|.
 </div>
 
 The <dfn>list of sufficiently strict speculative navigation referrer policies</dfn> is a list containing the following: "", "`strict-origin-when-cross-origin`", "`strict-origin`", "`same-origin`", "`no-referrer`".
@@ -447,7 +447,7 @@ The <dfn>list of sufficiently strict speculative navigation referrer policies</d
 
     1. [=Assert=]: |prefetchRecord|'s [=prefetch record/URL=]'s [=url/scheme=] is an [=HTTP(S) scheme=].
     1. [=list/Append=] |prefetchRecord| to |document|'s [=Document/prefetch records=].
-    1. If |prefetchRecord|'s [=prefetch record/referrer policy=] is not in the [=list of sufficiently strict speculative navigation referrer policies=], then [=prefetch record/cancel and discard=] |prefetchRecord| and return.
+    1. If |prefetchRecord|'s [=prefetch record/referrer policy=] is not in the [=list of sufficiently strict speculative navigation referrer policies=], then [=prefetch record/cancel and discard=] |prefetchRecord| given |document|, and return.
     1. Let |browsingContext| be |document|'s [=Document/browsing context=].
     1. Set |prefetchRecord|'s [=prefetch record/sandboxing flag set=] to the result of [=determining the creation sandboxing flags=] given |browsingContext| and |browsingContext|'s [=browsing context/container=].
     1. Let |isolationOrigin| be a new [=opaque origin=].
@@ -518,13 +518,13 @@ The <dfn>list of sufficiently strict speculative navigation referrer policies</d
     1. Let (|response|, |locationURL|) be the result of [=performing a common navigational fetch=] given |request|, "`other`", |browsingContext|, |isolatedEnvironment|, an empty algorithm, |shouldBlockNavigationRequest|, |shouldBlockNavigationResponse|, and |prefetchRecord|'s [=prefetch record/fetch controller=].
     1. If |locationURL| is failure or a [=URL=] whose [=url/scheme=] is not an [=HTTP(S) scheme=], then set |response| to a [=network error=].
     1. TODO: navigate-to, frame-src, XFO enforcement should probably be left to navigation, but what about Content-Disposition?
-    1. If |response| is a [=network error=], then [=prefetch record/cancel and discard=] |prefetchRecord| and return.
-    1. If |originsWithConflictingCredentials| is not empty, then [=prefetch record/cancel and discard=] |prefetchRecord| and return.
+    1. If |response| is a [=network error=], then [=prefetch record/cancel and discard=] |prefetchRecord| given |document|, and return.
+    1. If |originsWithConflictingCredentials| is not empty, then [=prefetch record/cancel and discard=] |prefetchRecord| given |document|, and return.
 
         <div class="note">This means that if any origin along the redirect chain had credentials, the prefetch is discarded. This reduces the chance of the user observing a logged-out page when they are logged in.</div>
     1. [=Assert=]: |response| is [=exchange record/response=] the last element of |prefetchRecord|'s [=prefetch record/redirect chain=].
-    1. If |response| does not [=support prefetch=], then [=prefetch record/cancel and discard=] |prefetchRecord| and return.
-    1. [=prefetch record/Complete=] |prefetchRecord|.
+    1. If |response| does not [=support prefetch=], then [=prefetch record/cancel and discard=] |prefetchRecord| given |document|, and return.
+    1. [=prefetch record/Complete=] |prefetchRecord| given |document|.
 
     <div class="issue">This ends up setting the `` `Cache-Control` `` and `` `Pragma` `` request headers, which is contrary to what Chromium does today when skipping cache here. One approach would be to add a flag similar to [=request/prevent no-cache cache-control header modification flag=]. It would also be possible to have a cache that can be copied into the ordinary cache, like Chromium does for cookies.</div>
 

--- a/prefetch.bs
+++ b/prefetch.bs
@@ -136,7 +136,7 @@ A <dfn export>prefetch record</dfn> is a [=struct=] with the following [=struct/
 * <dfn export for="prefetch record">URL</dfn>, a [=URL=]
 * <dfn export for="prefetch record">referrer policy</dfn>, a [=referrer policy=]
 * <dfn export for="prefetch record">anonymization policy</dfn>, a [=prefetch IP anonymization policy=]
-* <dfn export for="prefetch record">initiator</dfn>, a {{DOMString}}
+* <dfn export for="prefetch record">label</dfn>, a [=string=]
 
   <div class="note">This is intended for use by a specification or [=implementation-defined=] feature to identify which prefetches it created. It might also associate other data with this struct.</div>
 * <dfn export for="prefetch record">state</dfn>, which is `"ongoing"` (the default), `"completed"`, or `"canceled"`

--- a/prefetch.bs
+++ b/prefetch.bs
@@ -152,7 +152,7 @@ A <dfn export>prefetch record</dfn> is a [=struct=] with the following [=struct/
 
 A [=prefetch record=]'s <dfn export for="prefetch record">response</dfn> is the [=exchange record/response=] of the last element of its [=prefetch record/redirect chain=], or null if that list [=list/is empty=].
 
-The user agent may [=prefetch record/cancel and discard=] records from the [=Document/prefetch records=] even if they are not expired, e.g., due to resource constraints. Since completed records with expiry times in the past are never returned, they can be removed with no observable consequences.
+The user agent may [=prefetch record/cancel and discard=] records from the [=Document/prefetch records=] even if they are not expired, e.g., due to resource constraints. Since completed records with expiry times in the past will never be [=find a matching prefetch record|matching prefetch records=], they can be removed with no observable consequences.
 
 <div algorithm>
     To <dfn export for="prefetch record">cancel and discard</dfn> a [=prefetch record=] |prefetchRecord| given a {{Document}} |document|, perform the following steps.
@@ -435,7 +435,7 @@ These algorithms are based on [=process a navigate fetch=].
     1. If |locationURL| is failure or a [=URL=] whose [=url/scheme=] is not an [=HTTP(S) scheme=], then set |response| to a [=network error=].
     1. TODO: navigate-to, frame-src, XFO enforcement should probably be left to navigation, but what about Content-Disposition?
     1. If |response| is a [=network error=], then [=prefetch record/cancel and discard=] |prefetchRecord| given |document|, and return.
-    1. [=Assert=]: |response| is [=exchange record/response=] the last element of |prefetchRecord|'s [=prefetch record/redirect chain=].
+    1. [=Assert=]: |response| is the [=exchange record/response=] of |prefetchRecord|'s [=prefetch record/redirect chain=]'s last element.
     1. If |response| does not [=support prefetch=], then [=prefetch record/cancel and discard=] |prefetchRecord| given |document|, and return.
     1. [=prefetch record/Complete=] |prefetchRecord| given |document|.
 </div>
@@ -522,7 +522,7 @@ The <dfn>list of sufficiently strict speculative navigation referrer policies</d
     1. If |originsWithConflictingCredentials| is not empty, then [=prefetch record/cancel and discard=] |prefetchRecord| given |document|, and return.
 
         <div class="note">This means that if any origin along the redirect chain had credentials, the prefetch is discarded. This reduces the chance of the user observing a logged-out page when they are logged in.</div>
-    1. [=Assert=]: |response| is [=exchange record/response=] the last element of |prefetchRecord|'s [=prefetch record/redirect chain=].
+    1. [=Assert=]: |response| is the [=exchange record/response=] of |prefetchRecord|'s [=prefetch record/redirect chain=]'s last element.
     1. If |response| does not [=support prefetch=], then [=prefetch record/cancel and discard=] |prefetchRecord| given |document|, and return.
     1. [=prefetch record/Complete=] |prefetchRecord| given |document|.
 

--- a/prefetch.bs
+++ b/prefetch.bs
@@ -132,7 +132,7 @@ A <dfn>redirect chain</dfn> is a [=list=] of [=exchange records=].
 
 Each {{Document}} has <dfn export for="Document">prefetch records</dfn>, which is a [=list=] of [=prefetch records=].
 
-A <dfn>prefetch record</dfn> is a [=struct=] with the following [=struct/items=]:
+A <dfn export>prefetch record</dfn> is a [=struct=] with the following [=struct/items=]:
 * <dfn export for="prefetch record">URL</dfn>, a [=URL=]
 * <dfn export for="prefetch record">referrer policy</dfn>, a [=referrer policy=]
 * <dfn export for="prefetch record">anonymization policy</dfn>, a [=prefetch IP anonymization policy=]

--- a/prefetch.bs
+++ b/prefetch.bs
@@ -130,30 +130,50 @@ A <dfn>redirect chain</dfn> is a [=list=] of [=exchange records=].
 
 <hr>
 
-Each {{Document}} has a <dfn export>prefetch buffer</dfn>, which is a [=list=] of [=prefetch records=].
+Each {{Document}} has <dfn export for="Document">prefetch records</dfn>, which is a [=list=] of [=prefetch records=].
 
 A <dfn>prefetch record</dfn> is a [=struct=] with the following [=struct/items=]:
 * <dfn export for="prefetch record">URL</dfn>, a [=URL=]
 * <dfn export for="prefetch record">referrer policy</dfn>, a [=referrer policy=]
-* <dfn export for="prefetch record">sandbox flags present</dfn>, a boolean
-* <dfn export for="prefetch record">redirect chain</dfn>, a [=redirect chain=]
-* <dfn export for="prefetch record">expiry time</dfn>, a {{DOMHighResTimeStamp}}
+* <dfn export for="prefetch record">anonymization policy</dfn>, a [=prefetch IP anonymization policy=]
+* <dfn export for="prefetch record">initiator</dfn>, a {{DOMString}}
+
+  <div class="note">This is intended for use by a specification or [=implementation-defined=] feature to identify which prefetches it created. It might also associate other data with this struct.</div>
+* <dfn export for="prefetch record">state</dfn>, which is `"ongoing"` (the default), `"completed"`, or `"canceled"`
+
+  <div class="note">`"canceled"` indicates that the prefetch was aborted by the author or user, or terminated by the user agent.</div>
+* <dfn export for="prefetch record">fetch controller</dfn>, a [=fetch controller=] (a new [=fetch controller=] by default)
+* <dfn export for="prefetch record">sandboxing flag set</dfn>, a [=sandboxing flag set=]
+* <dfn export for="prefetch record">redirect chain</dfn>, a [=redirect chain=] (empty by default)
+* <dfn export for="prefetch record">expiry time</dfn>, a {{DOMHighResTimeStamp}} (0.0 by default)
 * <dfn for="prefetch record">isolated partition key</dfn>, a [=network partition key=] or null (the default)
+
+<div class="note">This tracks prefetches from when they are started to when they are ultimately used or discarded. Consequently some of these fields are immutable, some pertain to the ongoing activity (like [=prefetch record/fetch controller=]), and some (like [=prefetch record/expiry time=]) are populated when the prefetch completes.</div>
 
 A [=prefetch record=]'s <dfn export for="prefetch record">response</dfn> is the [=exchange record/response=] of the last element of its [=prefetch record/redirect chain=], or null if that list [=list/is empty=].
 
-The user agent may remove elements from the [=prefetch buffer=] even if they are not expired, e.g., due to resource constraints. Since records with expiry times in the past are never returned, they can be removed with no observable consequences.
+The user agent may [=prefetch record/cancel and discard=] records from the [=Document/prefetch records=] even if they are not expired, e.g., due to resource constraints. Since completed records with expiry times in the past are never returned, they can be removed with no observable consequences.
 
-<div algorithm="store a prefetch record">
-    To <dfn export>store a prefetch record</dfn> given a {{Document}} |document|, [=URL=] |url|, [=referrer policy=] |referrerPolicy|, [=sandboxing flag set=] |sandboxFlags|, [=redirect chain=] |redirectChain|, and [=network partition key=] or null |isolatedPartitionKey|, perform the following steps.
+<div algorithm>
+    To <dfn export for="prefetch record">cancel and discard</dfn> a [=prefetch record=] |prefetchRecord| given a {{Document}} |document|, perform the following steps.
+
+    1. [=Assert=]: |prefetchRecord| is in |document|'s [=Document/prefetch records=].
+    1. [=Assert=]: |prefetchRecord|'s [=prefetch record/state=] is not `"canceled"`.
+    1. Set |prefetchRecord|'s [=prefetch record/state=] to `"canceled"`.
+    1. [=fetch controller/Abort=] |prefetchRecord|'s [=prefetch record/fetch controller=]. <span class="note">This will cause any ongoing fetch to be canceled and yield a [=network error=].</span>
+    1. [=list/Remove=] |prefetchRecord| from |document|'s [=Document/prefetch records=].
+
+    <div class="note">This means that even a completed prefetch will not be served from the prefetch buffer. However, if it was part of the same partition as the document which requested it, it might still be stored in the ordinary HTTP cache.</div>
+</div>
+
+<div algorithm>
+    To <dfn export for="prefetch record">complete</dfn> a [=prefetch record=] |prefetchRecord| given {{Document}} |document|, perform the following steps.
 
     1. [=Assert=]: |document| is [=Document/fully active=].
     1. Let |currentTime| be the [=current high resolution time=] for the [=relevant global object=] of |document|.
     1. Let |expiryTime| be |currentTime| + 300000 (i.e., five minutes).
-    1. [=list/Remove=] all elements whose [=prefetch record/URL=] equals |url| and [=prefetch record/referrer policy=] equals |referrerPolicy| from |document|'s [=prefetch buffer=].
-    1. Let |prefetchRecord| be a [=prefetch record=] with [=prefetch record/URL=] |url|, [=prefetch record/referrer policy=] |referrerPolicy|, [=prefetch record/sandbox flags present=] true if |sandboxFlags| is not empty and false otherwise, [=prefetch record/redirect chain=] |redirectChain|, [=prefetch record/expiry time=] |expiryTime|, and [=prefetch record/isolated partition key=] |isolatedPartitionKey|.
-    1. [=list/Append=] |prefetchRecord| to |document|'s [=prefetch buffer=].
-    1. Return |prefetchRecord|.
+    1. [=list/Remove=] all elements of |document|'s [=Document/prefetch records=] which have the same [=prefetch record/URL=] and [=prefetch record/referrer policy=] as |prefetchRecord| and whose [=prefetch record/state=] equals `"completed"`.
+    1. Set |prefetchRecord|'s [=prefetch record/state=] to `"completed"` and [=prefetch record/expiry time=] to |expiryTime|.
 </div>
 
 <div algorithm="find a matching prefetch record">
@@ -161,18 +181,21 @@ The user agent may remove elements from the [=prefetch buffer=] even if they are
 
     1. [=Assert=]: |document| is [=Document/fully active=].
     1. Let |currentTime| be the [=current high resolution time=] for the [=relevant global object=] of |document|.
-    1. [=list/For each=] |record| of |document|'s [=prefetch buffer=]:
+    1. [=list/For each=] |record| of |document|'s [=Document/prefetch records=]:
         1. If |record|'s [=prefetch record/URL=] is not equal to |url| or |record|'s [=prefetch record/referrer policy=] is not equal to |referrerPolicy|, then [=iteration/continue=].
-        1. If |record|'s [=prefetch record/sandbox flags present=] is false and |sandboxFlags| is not empty, then [=iteration/continue=].
+        1. If |record|'s [=prefetch record/state=] is not `"completed"`, then [=iteration/continue=].
+        1. If |record|'s [=prefetch record/sandboxing flag set=] is empty and |sandboxFlags| is not empty, then [=iteration/continue=].
 
             <div class="note">
               Strictly speaking, it would still be possible for this to be valid if sandbox flags have been added to the container since prefetch but those flags would not cause an error due to cross origin opener policy. This is expected to be rare and so isn't handled.
             </div>
-        1. [=list/Remove=] |record| from |document|'s [=prefetch buffer=].
+        1. [=list/Remove=] |record| from |document|'s [=Document/prefetch records=].
         1. If |record|'s [=prefetch record/expiry time=] is less than |currentTime|, return null.
         1. If |record|'s [=prefetch record/redirect chain=] [=redirect chain/has updated credentials=], return null.
         1. Return |record|.
     1. Return null.
+
+    <p class="note">It's not obvious, but this doesn't actually require that the prefetch have received the complete body, just the response headers. In particular, a navigation to a prefetched response might nonetheless not load instantaneously.</p>
 
     <p class="issue">It might be possible to use cache response headers to determine when a response can be used multiple times, but given the short lifetime of the prefetch buffer it's unclear whether this is worthwhile.</p>
 </div>
@@ -226,26 +249,6 @@ A <dfn export>cross-origin prefetch IP anonymization policy</dfn> has an <dfn ex
       1. Return true.
   1. [=Assert=]: |policy| is null.
   1. Return false.
-</div>
-
-A <dfn export>prefetch controller</dfn> is a [=struct=] which allows managing a prefetch operation. It has the following [=items=]:
-* <dfn for="prefetch controller">state</dfn> (default `"ongoing"`), which is `"ongoing"` or `"aborted"`
-
-  <div class="note">The state is `"ongoing"` even after prefetch is complete, as long as it was not aborted by the author.</div>
-* <dfn for="prefetch controller">fetch controller</dfn> (default null), which is a [=fetch controller=] or null
-* <dfn for="prefetch controller">prefetch record</dfn> (default null), which is a [=prefetch record=] or nulll
-* <dfn export for="prefetch controller">document</dfn>, which is a {{Document}}
-
-  <div class="note">This is the {{Document}} whose [=prefetch buffer=] contains this's [=prefetch controller/prefetch record=], if any.
-
-<div algorithm>
-  To <dfn export for="prefetch controller">abort</dfn> a [=prefetch controller=] |prefetchController|:
-
-  1. Set |prefetchController|'s [=prefetch controller/state=] to `"aborted"`.
-  1. If |prefetchController|'s [=prefetch controller/fetch controller=] is not null, then [=fetch controller/abort=] it.
-  1. If |prefetchController|'s [=prefetch controller/prefetch record=] is not null, then [=list/remove=] it from |prefetchController|'s [=prefetch controller/document=]'s [=prefetch buffer=].
-
-  <div class="note">This means that even a completed prefetch will not be served from the prefetch buffer. However, if it was part of the same partition as the document which requested it, it might still be stored in the ordinary HTTP cache.</div>
 </div>
 
 <h2 id="html-patches">HTML Patches</h2>
@@ -367,18 +370,19 @@ These algorithms are based on [=process a navigate fetch=].
 <p class="issue">Check Service Worker integration</p>
 
 <div algorithm="partitioned prefetch">
-    To <dfn export>partitioned prefetch</dfn> given a {{Document}} |document|, [=URL=] |url|, [=referrer policy=] |referrerPolicy|, [=prefetch IP anonymization policy=] |anonymizationPolicy| and [=prefetch controller=] |prefetchController|, perform the following steps.
+    To <dfn export>partitioned prefetch</dfn> given a {{Document}} |document| and [=prefetch record=] |prefetchRecord|, perform the following steps.
 
-    1. [=Assert=]: |url|'s [=url/scheme=] is an [=HTTP(S) scheme=].
+    1. [=Assert=]: |prefetchRecord|'s [=prefetch record/URL=]'s [=url/scheme=] is an [=HTTP(S) scheme=].
+    1. [=list/Append=] |prefetchRecord| to |document|'s [=Document/prefetch records=].
     1. Let |partitionKey| be the result of [=determining the network partition key=] given |document|'s [=relevant settings object=].
     1. Let |browsingContext| be |document|'s [=Document/browsing context=].
-    1. Let |sandboxFlags| be the result of [=determining the creation sandboxing flags=] given |browsingContext| and |browsingContext|'s [=browsing context/container=].
+    1. Set |prefetchRecord|'s [=prefetch record/sandboxing flag set=] to the result of [=determining the creation sandboxing flags=] given |browsingContext| and |browsingContext|'s [=browsing context/container=].
     1. Let |request| be a [=request=] as follows:
 
         :  [=request/URL=]
-        :: |url|
+        :: |prefetchRecord|'s [=prefetch record/URL=]
         :  [=request/referrer policy=]
-        :: |referrerPolicy|
+        :: |prefetchRecord|'s [=prefetch record/referrer policy=]
         :  [=request/initiator=]
         :: "`prefetch`"
 
@@ -391,9 +395,7 @@ These algorithms are based on [=process a navigate fetch=].
         :: (set)
         :  [=request/client=]
         :: |document|'s [=relevant settings object=]
-        :  [=request/header list=]
 
-    1. Let |redirectChain| be an empty [=redirect chain=].
     1. Let |shouldBlockNavigationRequest| be the following steps, given [=request=] |request|, [=string=] |navigationType| and [=environment=] |environment|:
         1. [=Assert=]: |navigationType| is "`other`".
         1. [=Assert=]: |request|'s [=request/reserved client=] is |environment|.
@@ -418,51 +420,49 @@ These algorithms are based on [=process a navigate fetch=].
         1. If |request| cannot be fetched given |anonymizationPolicy| for an [=implementation-defined=] reason, then return "`Blocked`".
 
             <div class="note">This explicitly acknowledges that implementations might have additional restrictions. For instance, anonymized traffic might not be possible to some hosts, such as those that are not publicly routable and those that have <a href="https://buettner.github.io/private-prefetch-proxy/traffic-advice.html">traffic advice</a> declining private prefetch traffic.
-        1. [=redirect chain/Append=] |request| to |redirectChain|.
+        1. [=redirect chain/Append=] |request| to |prefetchRecord|'s [=prefetch record/redirect chain=].
         1. Return "`Allowed`".
 
     1. Let |shouldBlockNavigationResponse| be the following steps, given [=request=] |request| and [=response=] |response|:
         1. Let |responseCOOP| be the result of [=obtaining a cross-origin opener policy=] given |response| and |request|'s [=request/reserved client=].
-        1. If |sandboxFlags| is not empty and |responseCOOP|'s [=cross-origin opener policy/value=] is not "`unsafe-none`", then return "`Blocked`".
-        1. [=redirect chain/Update the response=] for |redirectChain| given |request| and |response|.
+        1. If |prefetchRecord|'s [=prefetch record/sandboxing flag set=] is not empty and |responseCOOP|'s [=cross-origin opener policy/value=] is not "`unsafe-none`", then return "`Blocked`".
+        1. [=redirect chain/Update the response=] for |prefetchRecord|'s [=prefetch record/redirect chain=] given |request| and |response|.
 
             <div class="note">This allows [=enforcing a response's cross-origin opener policy=] to be deferred, since this has visible side effects such as queuing violation reports.</div>
         1. Return "`Allowed`".
 
-    1. Let |fetchController| be a new [=fetch controller=].
-    1. Set |prefetchController|'s [=prefetch controller/fetch controller=] to |fetchController|.
-    1. Let (|response|, |locationURL|) be the result of [=performing a common navigational fetch=] given |request|, "`other`", |browsingContext|, null, an empty algorithm, |shouldBlockNavigationRequest|, and |shouldBlockNavigationResponse|, and |fetchController|.
+    1. Let (|response|, |locationURL|) be the result of [=performing a common navigational fetch=] given |request|, "`other`", |browsingContext|, null, an empty algorithm, |shouldBlockNavigationRequest|, and |shouldBlockNavigationResponse|, and |prefetchRecord|'s [=prefetch record/fetch controller=].
     1. If |locationURL| is failure or a [=URL=] whose [=url/scheme=] is not an [=HTTP(S) scheme=], then set |response| to a [=network error=].
     1. TODO: navigate-to, frame-src, XFO enforcement should probably be left to navigation, but what about Content-Disposition?
-    1. If |response| is a [=network error=], then return.
-    1. [=Assert=]: |response| is [=exchange record/response=] of |redirectChain|'s last element.
-    1. If |response| does not [=support prefetch=], then return.
-    1. Let |prefetchRecord| be the result of [=storing a prefetch record=] given |document|, |url|, |referrerPolicy|, |sandboxFlags|, |redirectChain| and null.
-    1. [=Assert=]: |prefetchController|'s [=prefetch controller/document=] is |document|.
-    1. Set |prefetchController|'s [=prefetch controller/prefetch record=] to |prefetchRecord|.
+    1. If |response| is a [=network error=], then [=prefetch record/cancel and discard=] |prefetchRecord| and return.
+    1. [=Assert=]: |response| is [=exchange record/response=] the last element of |prefetchRecord|'s [=prefetch record/redirect chain=].
+    1. If |response| does not [=support prefetch=], then [=prefetch record/cancel and discard=] |prefetchRecord| and return.
+    1. [=prefetch record/Complete=] |prefetchRecord|.
 </div>
 
 The <dfn>list of sufficiently strict speculative navigation referrer policies</dfn> is a list containing the following: "", "`strict-origin-when-cross-origin`", "`strict-origin`", "`same-origin`", "`no-referrer`".
 
 <div algorithm="uncredentialed prefetch">
-    To <dfn export>uncredentialed prefetch</dfn> given a {{Document}} |document|, [=URL=] |url|, [=referrer policy=] |referrerPolicy|, [=prefetch IP anonymization policy=] |anonymizationPolicy| and [=prefetch controller=] |prefetchController|, perform the following steps.
+    To <dfn export>uncredentialed prefetch</dfn> given a {{Document}} |document| and [=prefetch record=] |prefetchRecord|, perform the following steps.
 
-    1. [=Assert=]: |url|'s [=url/scheme=] is an [=HTTP(S) scheme=].
-    1. If |referrerPolicy| is not in the [=list of sufficiently strict speculative navigation referrer policies=], then return.
+    1. [=Assert=]: |prefetchRecord|'s [=prefetch record/URL=]'s [=url/scheme=] is an [=HTTP(S) scheme=].
+    1. [=list/Append=] |prefetchRecord| to |document|'s [=Document/prefetch records=].
+    1. If |prefetchRecord|'s [=prefetch record/referrer policy=] is not in the [=list of sufficiently strict speculative navigation referrer policies=], then [=prefetch record/cancel and discard=] |prefetchRecord| and return.
     1. Let |browsingContext| be |document|'s [=Document/browsing context=].
-    1. Let |sandboxFlags| be the result of [=determining the creation sandboxing flags=] given |browsingContext| and |browsingContext|'s [=browsing context/container=].
+    1. Set |prefetchRecord|'s [=prefetch record/sandboxing flag set=] to the result of [=determining the creation sandboxing flags=] given |browsingContext| and |browsingContext|'s [=browsing context/container=].
     1. Let |isolationOrigin| be a new [=opaque origin=].
 
         <div class="note">This is used to ensure a distinct network partition key is used.</div>
     1. Let |isolatedEnvironment| be a new [=environment=] whose [=environment/id=] is a unique opaque string, [=environment/target browsing context=] is |browsingContext|, [=environment/creation URL=] is `about:blank`, [=environment/top-level creation URL=] is `about:blank`, and [=environment/top-level origin=] is |isolationOrigin|.
     1. Let |isolatedPartitionKey| be the result of [=determining the network partition key=] given |isolatedEnvironment|.
     1. Let |originalPartitionKey| be the result of [=determining the network partition key=] given |document|'s [=relevant settings object=].
+    1. Set |prefetchRecord|'s [=prefetch record/isolated partition key=] to |isolatedPartitionKey|.
     1. Let |request| be a [=request=] as follows:
 
         :  [=request/URL=]
-        :: |url|
+        :: |prefetchRecord|'s [=prefetch record/URL=]
         :  [=request/referrer policy=]
-        :: |referrerPolicy|
+        :: |prefetchRecord|'s [=prefetch record/referrer policy=]
         :  [=request/initiator=]
         :: "`prefetch`"
 
@@ -479,7 +479,6 @@ The <dfn>list of sufficiently strict speculative navigation referrer policies</d
         :: |document|'s [=relevant settings object=]
 
     1. Let |originsWithConflictingCredentials| be an empty [=ordered set=].
-    1. Let |redirectChain| be an empty [=redirect chain=].
     1. Let |shouldBlockNavigationRequest| be the following steps, given [=request=] |request|, [=string=] |navigationType| and [=environment=] |environment|:
         1. [=Assert=]: |request|'s [=request/reserved client=] is |isolatedEnvironment| and not |environment|.
         1. [=Assert=]: |navigationType| is "`other`".
@@ -505,31 +504,27 @@ The <dfn>list of sufficiently strict speculative navigation referrer policies</d
         1. If |request| cannot be fetched given |anonymizationPolicy| for an [=implementation-defined=] reason, then return "`Blocked`".
 
             <div class="note">This explicitly acknowledges that implementations might have additional restrictions. For instance, anonymized traffic might not be possible to some hosts, such as those that are not publicly routable and those that have <a href="https://buettner.github.io/private-prefetch-proxy/traffic-advice.html">traffic advice</a> declining private prefetch traffic.
-        1. [=redirect chain/Append=] |request| to |redirectChain|.
+        1. [=redirect chain/Append=] |request| to |prefetchRecord|'s [=prefetch record/redirect chain=].
         1. Return "`Allowed`".
 
     1. Let |shouldBlockNavigationResponse| be the following steps, given [=request=] |request| and [=response=] |response|:
         1. Let |responseCOOP| be the result of [=obtaining a cross-origin opener policy=] given |response| and |request|'s [=request/reserved client=].
-        1. If |sandboxFlags| is not empty and |responseCOOP|'s [=cross-origin opener policy/value=] is not "`unsafe-none`", then return "`Blocked`".
-        1. [=redirect chain/Update the response=] for |redirectChain| given |request| and |response|.
+        1. If |prefetchRecord|'s [=prefetch record/sandboxing flag set=] is not empty and |responseCOOP|'s [=cross-origin opener policy/value=] is not "`unsafe-none`", then return "`Blocked`".
+        1. [=redirect chain/Update the response=] for |prefetchRecord|'s [=prefetch record/redirect chain=] given |request| and |response|.
 
             <div class="note">This allows [=enforcing a response's cross-origin opener policy=] to be deferred, since this has visible side effects such as queuing violation reports.</div>
         1. Return "`Allowed`".
 
-    1. Let |fetchController| be a new [=fetch controller=].
-    1. Set |prefetchController|'s [=prefetch controller/fetch controller=] to |fetchController|.
-    1. Let (|response|, |locationURL|) be the result of [=performing a common navigational fetch=] given |request|, "`other`", |browsingContext|, |isolatedEnvironment|, an empty algorithm, |shouldBlockNavigationRequest|, |shouldBlockNavigationResponse|, and |fetchController|.
+    1. Let (|response|, |locationURL|) be the result of [=performing a common navigational fetch=] given |request|, "`other`", |browsingContext|, |isolatedEnvironment|, an empty algorithm, |shouldBlockNavigationRequest|, |shouldBlockNavigationResponse|, and |prefetchRecord|'s [=prefetch record/fetch controller=].
     1. If |locationURL| is failure or a [=URL=] whose [=url/scheme=] is not an [=HTTP(S) scheme=], then set |response| to a [=network error=].
     1. TODO: navigate-to, frame-src, XFO enforcement should probably be left to navigation, but what about Content-Disposition?
-    1. If |response| is a [=network error=], then return.
-    1. If |originsWithConflictingCredentials| is not empty, then return.
+    1. If |response| is a [=network error=], then [=prefetch record/cancel and discard=] |prefetchRecord| and return.
+    1. If |originsWithConflictingCredentials| is not empty, then [=prefetch record/cancel and discard=] |prefetchRecord| and return.
 
         <div class="note">This means that if any origin along the redirect chain had credentials, the prefetch is discarded. This reduces the chance of the user observing a logged-out page when they are logged in.</div>
-    1. [=Assert=]: |response| is [=exchange record/response=] of |redirectChain|'s last element.
-    1. If |response| does not [=support prefetch=], then return.
-    1. Let |prefetchRecord| be the result of [=storing a prefetch record=] given |document|, |url|, |referrerPolicy|, |sandboxFlags|, |redirectChain| and |isolatedPartitionKey|.
-    1. [=Assert=]: |prefetchController|'s [=prefetch controller/document=] is |document|.
-    1. Set |prefetchController|'s [=prefetch controller/prefetch record=] to |prefetchRecord|.
+    1. [=Assert=]: |response| is [=exchange record/response=] the last element of |prefetchRecord|'s [=prefetch record/redirect chain=].
+    1. If |response| does not [=support prefetch=], then [=prefetch record/cancel and discard=] |prefetchRecord| and return.
+    1. [=prefetch record/Complete=] |prefetchRecord|.
 
     <div class="issue">This ends up setting the `` `Cache-Control` `` and `` `Pragma` `` request headers, which is contrary to what Chromium does today when skipping cache here. One approach would be to add a flag similar to [=request/prevent no-cache cache-control header modification flag=]. It would also be possible to have a cache that can be copied into the ordinary cache, like Chromium does for cookies.</div>
 
@@ -537,14 +532,14 @@ The <dfn>list of sufficiently strict speculative navigation referrer policies</d
 </div>
 
 <div algorithm>
-    To <dfn export>prefetch</dfn> given a {{Document}} |document|, [=URL=] |url|, [=referrer policy=] |referrerPolicy|, [=prefetch IP anonymization policy=] |anonymizationPolicy|, and [=prefetch controller=] |prefetchController|, perform the following steps.
+    To <dfn export>prefetch</dfn> given a {{Document}} |document| and [=prefetch record=] |prefetchRecord|, perform the following steps.
 
     1. Let |partitionKey| be the result of [=determining the network partition key=] given |document|'s [=relevant settings object=].
-    1. Let |topLevelOrigin| be |url|'s [=url/origin=] if |document|'s [=Document/browsing context=] is a [=top-level browsing context=], and |document|'s [=relevant settings object=]'s [=environment/top-level origin=] otherwise.
+    1. Let |topLevelOrigin| be |prefetchRecord|'s [=prefetch record/URL=]'s [=url/origin=] if |document|'s [=Document/browsing context=] is a [=top-level browsing context=], and |document|'s [=relevant settings object=]'s [=environment/top-level origin=] otherwise.
     1. Let |topLevelSite| be the result of [=obtaining a site=], given |topLevelOrigin|.
     1. Let |secondKey| be null or an [=implementation-defined=] value.
-    1. If |partitionKey| is equal to (|topLevelSite|, |secondKey|), then [=partitioned prefetch=] given |document|, |url|, |referrerPolicy|, |anonymizationPolicy|, and |prefetchController|.
-    1. Otherwise, [=uncredentialed prefetch=] given |document|, |url|, |referrerPolicy|, |anonymizationPolicy|, and |prefetchController|.
+    1. If |partitionKey| is equal to (|topLevelSite|, |secondKey|), then [=partitioned prefetch=] given |document| and |prefetchRecord|.
+    1. Otherwise, [=uncredentialed prefetch=] given |document| and |prefetchRecord|.
 
     <div class="note">
       This determines whether the navigation would use the same network partition key.

--- a/prefetch.bs
+++ b/prefetch.bs
@@ -61,6 +61,7 @@ spec: fetch; urlPrefix: https://fetch.spec.whatwg.org/
   type: dfn
     text: process response; url: process-response
     text: network partition key; url: network-partition-key
+    text: controller; for: fetch params; url: fetch-params-controller
 spec: RFC8941; urlPrefix: https://www.rfc-editor.org/rfc/rfc8941.html
   type: dfn
     text: Item; url: name-items
@@ -150,7 +151,9 @@ The user agent may remove elements from the [=prefetch buffer=] even if they are
     1. Let |currentTime| be the [=current high resolution time=] for the [=relevant global object=] of |document|.
     1. Let |expiryTime| be |currentTime| + 300000 (i.e., five minutes).
     1. [=list/Remove=] all elements whose [=prefetch record/URL=] equals |url| and [=prefetch record/referrer policy=] equals |referrerPolicy| from |document|'s [=prefetch buffer=].
-    1. [=list/Append=] a [=prefetch record=] with [=prefetch record/URL=] |url|, [=prefetch record/referrer policy=] |referrerPolicy|, [=prefetch record/sandbox flags present=] true if |sandboxFlags| is not empty and false otherwise, [=prefetch record/redirect chain=] |redirectChain|, [=prefetch record/expiry time=] |expiryTime|, and [=prefetch record/isolated partition key=] |isolatedPartitionKey| to |document|'s [=prefetch buffer=].
+    1. Let |prefetchRecord| be a [=prefetch record=] with [=prefetch record/URL=] |url|, [=prefetch record/referrer policy=] |referrerPolicy|, [=prefetch record/sandbox flags present=] true if |sandboxFlags| is not empty and false otherwise, [=prefetch record/redirect chain=] |redirectChain|, [=prefetch record/expiry time=] |expiryTime|, and [=prefetch record/isolated partition key=] |isolatedPartitionKey|.
+    1. [=list/Append=] |prefetchRecord| to |document|'s [=prefetch buffer=].
+    1. Return |prefetchRecord|.
 </div>
 
 <div algorithm="find a matching prefetch record">
@@ -225,12 +228,32 @@ A <dfn export>cross-origin prefetch IP anonymization policy</dfn> has an <dfn ex
   1. Return false.
 </div>
 
+A <dfn export>prefetch controller</dfn> is a [=struct=] which allows managing a prefetch operation. It has the following [=items=]:
+* <dfn for="prefetch controller">state</dfn> (default `"ongoing"`), which is `"ongoing"` or `"aborted"`
+
+  <div class="note">The state is `"ongoing"` even after prefetch is complete, as long as it was not aborted by the author.</div>
+* <dfn for="prefetch controller">fetch controller</dfn> (default null), which is a [=fetch controller=] or null
+* <dfn for="prefetch controller">prefetch record</dfn> (default null), which is a [=prefetch record=] or nulll
+* <dfn export for="prefetch controller">document</dfn>, which is a {{Document}}
+
+  <div class="note">This is the {{Document}} whose [=prefetch buffer=] contains this's [=prefetch controller/prefetch record=], if any.
+
+<div algorithm>
+  To <dfn export for="prefetch controller">abort</dfn> a [=prefetch controller=] |prefetchController|:
+
+  1. Set |prefetchController|'s [=prefetch controller/state=] to `"aborted"`.
+  1. If |prefetchController|'s [=prefetch controller/fetch controller=] is not null, then [=fetch controller/abort=] it.
+  1. If |prefetchController|'s [=prefetch controller/prefetch record=] is not null, then [=list/remove=] it from |prefetchController|'s [=prefetch controller/document=]'s [=prefetch buffer=].
+
+  <div class="note">This means that even a completed prefetch will not be served from the prefetch buffer. However, if it was part of the same partition as the document which requested it, it might still be stored in the ordinary HTTP cache.</div>
+</div>
+
 <h2 id="html-patches">HTML Patches</h2>
 
 <div algorithm="perform a common navigational fetch">
     <div class="note">This is an abstraction of the existing [=process a navigate fetch=]. It includes behavior like redirect handling that is particular to navigational fetches, including those that are relate to a speculate future navigation, rather than an immediate one.</div>
 
-    To <dfn export>perform a common navigational fetch</dfn> given a [=request=] |request|, [=string=] |navigationType|, [=browsing context=] |browsingContext|, [=environment=] or null |forceEnvironment|, algorithm |preRedirectHook| (which takes [=URLs=] currentURL and locationURL) algorithm |shouldBlockNavigationRequest| (which takes a [=request=], navigation type [=string=], and [=environment=], and returns "`Blocked`" or "`Allowed`"), algorithm |shouldBlockNavigationResponse| (which takes a [=request=] and a [=response=], and returns "`Blocked`" or "`Allowed`"), perform the following steps.
+    To <dfn export>perform a common navigational fetch</dfn> given a [=request=] |request|, [=string=] |navigationType|, [=browsing context=] |browsingContext|, [=environment=] or null |forceEnvironment|, algorithm |preRedirectHook| (which takes [=URLs=] currentURL and locationURL) algorithm |shouldBlockNavigationRequest| (which takes a [=request=], navigation type [=string=], and [=environment=], and returns "`Blocked`" or "`Allowed`"), algorithm |shouldBlockNavigationResponse| (which takes a [=request=] and a [=response=], and returns "`Blocked`" or "`Allowed`"), and [=fetch controller=] |fetchController| (default a new [=fetch controller=]), perform the following steps.
 
     1. Let |response| be null.
     1. Set |request|'s [=request/mode=] to "`navigate`" and [=request/redirect mode=] to "`manual`".
@@ -238,6 +261,7 @@ A <dfn export>cross-origin prefetch IP anonymization policy</dfn> has an <dfn ex
     1. Let |environment| be null.
     1. Let |locationURL| be null.
     1. Let |currentURL| be |request|'s [=request/current URL=].
+    1. Let |fetchParams| be null.
 
     1. While true:
         1. If |locationURL| is non-null, then:
@@ -259,8 +283,10 @@ A <dfn export>cross-origin prefetch IP anonymization policy</dfn> has an <dfn ex
             <div class="note">These steps ensure that |environment| is an [=environment=] which the correct [=network partition key=], [=environment/active service worker=], etc., depending on whether it's a top-level navigation and if not, what the top-level site is.</div>
 
         1. If the result of |shouldBlockNavigationRequest| given |request|, |navigationType|, and |environment| is "`Blocked`", then set |response| to a [=network error=] and [=iteration/break=].
-        1. If |response| is null, [=fetch=] |request|.
-        1. Otherwise, perform [=HTTP-redirect fetch=] using |request| and |response|.
+        1. If |response| is null, [=fetch=] |request|. When it initializes |fetchParams|, use |fetchController| as its [=fetch params/controller=]. Set |fetchParams| to the final value it has in that algorithm.
+
+            <div class="issue">This is messy due to ongoing work to refactor navigation in HTML, and should be cleaned up when possible.</div>
+        1. Otherwise, perform [=HTTP-redirect fetch=] using |fetchParams| and |response|.
         1. Wait for the [=task=] on the [=networking task source=] to [=process response=] and set |response| to the result.
         1. If the result of |shouldBlockNavigationResponse| given |request| and |response| is "`Blocked`", then set |response| to a [=network error=] and [=iteration/break=].
         1. If |response| is not a [=network error=], |browsingContext| is a [=child browsing context=], and the result of performing a [=cross-origin resource policy check=] with |browsingContext|'s [=browsing context/container document=]'s [=Document/origin=], |browsingContext|'s [=browsing context/container document=]'s [=relevant settings object=], |request|'s [=request/destination=], |response|, and true is <strong>blocked</strong>, then set |response| to a [=network error=] and [=iteration/break=].
@@ -341,7 +367,7 @@ These algorithms are based on [=process a navigate fetch=].
 <p class="issue">Check Service Worker integration</p>
 
 <div algorithm="partitioned prefetch">
-    To <dfn export>partitioned prefetch</dfn> given a {{Document}} |document|, [=URL=] |url|, [=referrer policy=] |referrerPolicy|, and [=prefetch IP anonymization policy=] |anonymizationPolicy|, perform the following steps.
+    To <dfn export>partitioned prefetch</dfn> given a {{Document}} |document|, [=URL=] |url|, [=referrer policy=] |referrerPolicy|, [=prefetch IP anonymization policy=] |anonymizationPolicy| and [=prefetch controller=] |prefetchController|, perform the following steps.
 
     1. [=Assert=]: |url|'s [=url/scheme=] is an [=HTTP(S) scheme=].
     1. Let |partitionKey| be the result of [=determining the network partition key=] given |document|'s [=relevant settings object=].
@@ -403,19 +429,23 @@ These algorithms are based on [=process a navigate fetch=].
             <div class="note">This allows [=enforcing a response's cross-origin opener policy=] to be deferred, since this has visible side effects such as queuing violation reports.</div>
         1. Return "`Allowed`".
 
-    1. Let (|response|, |locationURL|) be the result of [=performing a common navigational fetch=] given |request|, "`other`", |browsingContext|, null, an empty algorithm, |shouldBlockNavigationRequest|, and |shouldBlockNavigationResponse|.
+    1. Let |fetchController| be a new [=fetch controller=].
+    1. Set |prefetchController|'s [=prefetch controller/fetch controller=] to |fetchController|.
+    1. Let (|response|, |locationURL|) be the result of [=performing a common navigational fetch=] given |request|, "`other`", |browsingContext|, null, an empty algorithm, |shouldBlockNavigationRequest|, and |shouldBlockNavigationResponse|, and |fetchController|.
     1. If |locationURL| is failure or a [=URL=] whose [=url/scheme=] is not an [=HTTP(S) scheme=], then set |response| to a [=network error=].
     1. TODO: navigate-to, frame-src, XFO enforcement should probably be left to navigation, but what about Content-Disposition?
     1. If |response| is a [=network error=], then return.
     1. [=Assert=]: |response| is [=exchange record/response=] of |redirectChain|'s last element.
     1. If |response| does not [=support prefetch=], then return.
-    1. [=Store a prefetch record=] given |document|, |url|, |referrerPolicy|, |sandboxFlags|, |redirectChain| and null.
+    1. Let |prefetchRecord| be the result of [=storing a prefetch record=] given |document|, |url|, |referrerPolicy|, |sandboxFlags|, |redirectChain| and null.
+    1. [=Assert=]: |prefetchController|'s [=prefetch controller/document=] is |document|.
+    1. Set |prefetchController|'s [=prefetch controller/prefetch record=] to |prefetchRecord|.
 </div>
 
 The <dfn>list of sufficiently strict speculative navigation referrer policies</dfn> is a list containing the following: "", "`strict-origin-when-cross-origin`", "`strict-origin`", "`same-origin`", "`no-referrer`".
 
 <div algorithm="uncredentialed prefetch">
-    To <dfn export>uncredentialed prefetch</dfn> given a {{Document}} |document|, [=URL=] |url|, [=referrer policy=] |referrerPolicy|, and [=prefetch IP anonymization policy=] |anonymizationPolicy|, perform the following steps.
+    To <dfn export>uncredentialed prefetch</dfn> given a {{Document}} |document|, [=URL=] |url|, [=referrer policy=] |referrerPolicy|, [=prefetch IP anonymization policy=] |anonymizationPolicy| and [=prefetch controller=] |prefetchController|, perform the following steps.
 
     1. [=Assert=]: |url|'s [=url/scheme=] is an [=HTTP(S) scheme=].
     1. If |referrerPolicy| is not in the [=list of sufficiently strict speculative navigation referrer policies=], then return.
@@ -486,7 +516,9 @@ The <dfn>list of sufficiently strict speculative navigation referrer policies</d
             <div class="note">This allows [=enforcing a response's cross-origin opener policy=] to be deferred, since this has visible side effects such as queuing violation reports.</div>
         1. Return "`Allowed`".
 
-    1. Let (|response|, |locationURL|) be the result of [=performing a common navigational fetch=] given |request|, "`other`", |browsingContext|, |isolatedEnvironment|, an empty algorithm, |shouldBlockNavigationRequest|, and |shouldBlockNavigationResponse|.
+    1. Let |fetchController| be a new [=fetch controller=].
+    1. Set |prefetchController|'s [=prefetch controller/fetch controller=] to |fetchController|.
+    1. Let (|response|, |locationURL|) be the result of [=performing a common navigational fetch=] given |request|, "`other`", |browsingContext|, |isolatedEnvironment|, an empty algorithm, |shouldBlockNavigationRequest|, |shouldBlockNavigationResponse|, and |fetchController|.
     1. If |locationURL| is failure or a [=URL=] whose [=url/scheme=] is not an [=HTTP(S) scheme=], then set |response| to a [=network error=].
     1. TODO: navigate-to, frame-src, XFO enforcement should probably be left to navigation, but what about Content-Disposition?
     1. If |response| is a [=network error=], then return.
@@ -495,7 +527,9 @@ The <dfn>list of sufficiently strict speculative navigation referrer policies</d
         <div class="note">This means that if any origin along the redirect chain had credentials, the prefetch is discarded. This reduces the chance of the user observing a logged-out page when they are logged in.</div>
     1. [=Assert=]: |response| is [=exchange record/response=] of |redirectChain|'s last element.
     1. If |response| does not [=support prefetch=], then return.
-    1. [=Store a prefetch record=] given |document|, |url|, |referrerPolicy|, |sandboxFlags|, |redirectChain| and |isolatedPartitionKey|.
+    1. Let |prefetchRecord| be the result of [=storing a prefetch record=] given |document|, |url|, |referrerPolicy|, |sandboxFlags|, |redirectChain| and |isolatedPartitionKey|.
+    1. [=Assert=]: |prefetchController|'s [=prefetch controller/document=] is |document|.
+    1. Set |prefetchController|'s [=prefetch controller/prefetch record=] to |prefetchRecord|.
 
     <div class="issue">This ends up setting the `` `Cache-Control` `` and `` `Pragma` `` request headers, which is contrary to what Chromium does today when skipping cache here. One approach would be to add a flag similar to [=request/prevent no-cache cache-control header modification flag=]. It would also be possible to have a cache that can be copied into the ordinary cache, like Chromium does for cookies.</div>
 
@@ -503,14 +537,14 @@ The <dfn>list of sufficiently strict speculative navigation referrer policies</d
 </div>
 
 <div algorithm>
-    To <dfn export>prefetch</dfn> given a {{Document}} |document|, [=URL=] |url|, [=referrer policy=] |referrerPolicy|, and [=prefetch IP anonymization policy=] |anonymizationPolicy|, perform the following steps.
+    To <dfn export>prefetch</dfn> given a {{Document}} |document|, [=URL=] |url|, [=referrer policy=] |referrerPolicy|, [=prefetch IP anonymization policy=] |anonymizationPolicy|, and [=prefetch controller=] |prefetchController|, perform the following steps.
 
     1. Let |partitionKey| be the result of [=determining the network partition key=] given |document|'s [=relevant settings object=].
     1. Let |topLevelOrigin| be |url|'s [=url/origin=] if |document|'s [=Document/browsing context=] is a [=top-level browsing context=], and |document|'s [=relevant settings object=]'s [=environment/top-level origin=] otherwise.
     1. Let |topLevelSite| be the result of [=obtaining a site=], given |topLevelOrigin|.
     1. Let |secondKey| be null or an [=implementation-defined=] value.
-    1. If |partitionKey| is equal to (|topLevelSite|, |secondKey|), then [=partitioned prefetch=] given |document|, |url|, |referrerPolicy| and |anonymizationPolicy|.
-    1. Otherwise, [=uncredentialed prefetch=] given |document|, |url|, |referrerPolicy| and |anonymizationPolicy|.
+    1. If |partitionKey| is equal to (|topLevelSite|, |secondKey|), then [=partitioned prefetch=] given |document|, |url|, |referrerPolicy|, |anonymizationPolicy|, and |prefetchController|.
+    1. Otherwise, [=uncredentialed prefetch=] given |document|, |url|, |referrerPolicy|, |anonymizationPolicy|, and |prefetchController|.
 
     <div class="note">
       This determines whether the navigation would use the same network partition key.

--- a/prefetch.bs
+++ b/prefetch.bs
@@ -139,9 +139,9 @@ A <dfn export>prefetch record</dfn> is a [=struct=] with the following [=struct/
 * <dfn export for="prefetch record">label</dfn>, a [=string=]
 
   <div class="note">This is intended for use by a specification or [=implementation-defined=] feature to identify which prefetches it created. It might also associate other data with this struct.</div>
-* <dfn export for="prefetch record">state</dfn>, which is `"ongoing"` (the default), `"completed"`, or `"canceled"`
+* <dfn export for="prefetch record">state</dfn>, which is "`ongoing`" (the default), "`completed`", or "`canceled`"
 
-  <div class="note">`"canceled"` indicates that the prefetch was aborted by the author or user, or terminated by the user agent.</div>
+  <div class="note">"`canceled`" indicates that the prefetch was aborted by the author or user, or terminated by the user agent.</div>
 * <dfn export for="prefetch record">fetch controller</dfn>, a [=fetch controller=] (a new [=fetch controller=] by default)
 * <dfn export for="prefetch record">sandboxing flag set</dfn>, a [=sandboxing flag set=]
 * <dfn export for="prefetch record">redirect chain</dfn>, a [=redirect chain=] (empty by default)
@@ -158,8 +158,8 @@ The user agent may [=prefetch record/cancel and discard=] records from the [=Doc
     To <dfn export for="prefetch record">cancel and discard</dfn> a [=prefetch record=] |prefetchRecord| given a {{Document}} |document|, perform the following steps.
 
     1. [=Assert=]: |prefetchRecord| is in |document|'s [=Document/prefetch records=].
-    1. [=Assert=]: |prefetchRecord|'s [=prefetch record/state=] is not `"canceled"`.
-    1. Set |prefetchRecord|'s [=prefetch record/state=] to `"canceled"`.
+    1. [=Assert=]: |prefetchRecord|'s [=prefetch record/state=] is not "`canceled`".
+    1. Set |prefetchRecord|'s [=prefetch record/state=] to "`canceled`".
     1. [=fetch controller/Abort=] |prefetchRecord|'s [=prefetch record/fetch controller=]. <span class="note">This will cause any ongoing fetch to be canceled and yield a [=network error=].</span>
     1. [=list/Remove=] |prefetchRecord| from |document|'s [=Document/prefetch records=].
 
@@ -172,8 +172,8 @@ The user agent may [=prefetch record/cancel and discard=] records from the [=Doc
     1. [=Assert=]: |document| is [=Document/fully active=].
     1. Let |currentTime| be the [=current high resolution time=] for the [=relevant global object=] of |document|.
     1. Let |expiryTime| be |currentTime| + 300000 (i.e., five minutes).
-    1. [=list/Remove=] all elements of |document|'s [=Document/prefetch records=] which have the same [=prefetch record/URL=] and [=prefetch record/referrer policy=] as |prefetchRecord| and whose [=prefetch record/state=] equals `"completed"`.
-    1. Set |prefetchRecord|'s [=prefetch record/state=] to `"completed"` and [=prefetch record/expiry time=] to |expiryTime|.
+    1. [=list/Remove=] all elements of |document|'s [=Document/prefetch records=] which have the same [=prefetch record/URL=] and [=prefetch record/referrer policy=] as |prefetchRecord| and whose [=prefetch record/state=] equals "`completed`".
+    1. Set |prefetchRecord|'s [=prefetch record/state=] to "`completed`" and [=prefetch record/expiry time=] to |expiryTime|.
 </div>
 
 <div algorithm="find a matching prefetch record">
@@ -183,7 +183,7 @@ The user agent may [=prefetch record/cancel and discard=] records from the [=Doc
     1. Let |currentTime| be the [=current high resolution time=] for the [=relevant global object=] of |document|.
     1. [=list/For each=] |record| of |document|'s [=Document/prefetch records=]:
         1. If |record|'s [=prefetch record/URL=] is not equal to |url| or |record|'s [=prefetch record/referrer policy=] is not equal to |referrerPolicy|, then [=iteration/continue=].
-        1. If |record|'s [=prefetch record/state=] is not `"completed"`, then [=iteration/continue=].
+        1. If |record|'s [=prefetch record/state=] is not "`completed`", then [=iteration/continue=].
         1. If |record|'s [=prefetch record/sandboxing flag set=] is empty and |sandboxFlags| is not empty, then [=iteration/continue=].
 
             <div class="note">

--- a/speculation-rules.bs
+++ b/speculation-rules.bs
@@ -247,8 +247,8 @@ A <dfn>prerender candidate</dfn> is a [=struct=] with the following [=struct/ite
 
 <div algorithm>
   A [=prefetch candidate=] |prefetchCandidate| <dfn for="prefetch candidate">continues</dfn> a [=prefetch record=] |prefetchRecord| if the following are all true:
-  * |prefetchRecord|'s [=prefetch record/label=] is `"speculation-rules"`
-  * |prefetchRecord|'s [=prefetch record/state=] is not `"canceled"`
+  * |prefetchRecord|'s [=prefetch record/label=] is "`speculation-rules`"
+  * |prefetchRecord|'s [=prefetch record/state=] is not "`canceled`"
   * |prefetchRecord|'s [=prefetch record/URL=] equals |prefetchCandidate|'s [=prefetch candidate/URL=]
   * |prefetchRecord|'s [=prefetch record/anonymization policy=] equals |prefetchCandidate|'s [=prefetch candidate/anonymization policy=]
 </div>
@@ -271,13 +271,13 @@ A <dfn>prerender candidate</dfn> is a [=struct=] with the following [=struct/ite
       1. &#x231B; [=list/For each=] |url| of |rule|'s [=speculation rule/URLs=]:
         1. &#x231B; [=list/Append=] a [=prerender candidate=] with [=prerender candidate/URL=] |url| and [=prerender candidate/referrer policy=] "`strict-origin-when-cross-origin`" to |prerenderCandidates|.
   1. &#x231B; [=list/For each=] |prefetchRecord| of |document|'s [=Document/prefetch records=]:
-    1. &#x231B; If |prefetchRecord|'s [=prefetch record/label=] is not `"speculation-rules"`, then [=iteration/continue=].
-    1. &#x231B; [=Assert=]: |prefetchRecord|'s [=prefetch record/state=] is not `"canceled"`.
+    1. &#x231B; If |prefetchRecord|'s [=prefetch record/label=] is not "`speculation-rules`", then [=iteration/continue=].
+    1. &#x231B; [=Assert=]: |prefetchRecord|'s [=prefetch record/state=] is not "`canceled`".
     1. &#x231B; If no element of |prefetchCandidates| [=prefetch candidate/continues=] |prefetchRecord|, then [=prefetch record/cancel and discard=] |prefetchRecord| given |document|.
   1. End the [=synchronous section=], continuing the remaining steps [=in parallel=].
   1. [=list/For each=] |prefetchCandidate| of |prefetchCandidates|:
     1. The user agent may run the following steps:
-      1. Let |prefetchRecord| be a new [=prefetch record=] whose [=prefetch record/URL=] is |prefetchCandidate|'s [=prefetch candidate/URL=], [=prefetch record/referrer policy=] is |prefetchCandidate|'s [=prefetch candidate/referrer policy=], [=prefetch record/anonymization policy=] is |prefetchCandidate|'s [=prefetch candidate/anonymization policy=], and [=prefetch record/label=] is `"speculation-rules"`.
+      1. Let |prefetchRecord| be a new [=prefetch record=] whose [=prefetch record/URL=] is |prefetchCandidate|'s [=prefetch candidate/URL=], [=prefetch record/referrer policy=] is |prefetchCandidate|'s [=prefetch candidate/referrer policy=], [=prefetch record/anonymization policy=] is |prefetchCandidate|'s [=prefetch candidate/anonymization policy=], and [=prefetch record/label=] is "`speculation-rules`".
       1. [=Prefetch=] given |document| and |prefetchRecord|.
   1. [=list/For each=] |prerenderCandidate| of |prefetchCandidates|:
       1. The user agent may [=create a prerendering browsing context=] given |prerenderCandidate|'s [=prerender candidate/URL=], |prerenderCandidate|'s [=prerender candidate/referrer policy=] and |document|.

--- a/speculation-rules.bs
+++ b/speculation-rules.bs
@@ -276,8 +276,8 @@ A {{Document}} has <dfn for=Document export>started prefetches</dfn>, which is a
   1. [=list/For each=] |prefetchCandidate| of |prefetchCandidates|:
     1. The user agent may run the following steps:
       1. Let |prefetchController| be a new [=prefetch controller=] whose [=prefetch controller/document=] is |document|.
-      1. [=Prefetch=] given |document|, |prefetchCandidate|'s [=prefetch candidate/URL=], |prefetchCandidate|'s [=prefetch candidate/referrer policy=], |prefetchCandidate|'s [=prefetch candidate/anonymization policy=], and |prefetchController|.
       1. [=list/Append=] a new [=started prefetch=] whose [=started prefetch/candidate=] is |prefetchCandidate| and [=started prefetch/controller=] is |prefetchController| to |document|'s [=Document/started prefetches=].
+      1. [=Prefetch=] given |document|, |prefetchCandidate|'s [=prefetch candidate/URL=], |prefetchCandidate|'s [=prefetch candidate/referrer policy=], |prefetchCandidate|'s [=prefetch candidate/anonymization policy=], and |prefetchController|.
   1. [=list/For each=] |prerenderCandidate| of |prefetchCandidates|:
       1. The user agent may [=create a prerendering browsing context=] given |prerenderCandidate|'s [=prerender candidate/URL=], |prerenderCandidate|'s [=prerender candidate/referrer policy=] and |document|.
 </div>

--- a/speculation-rules.bs
+++ b/speculation-rules.bs
@@ -273,7 +273,7 @@ A <dfn>prerender candidate</dfn> is a [=struct=] with the following [=struct/ite
   1. &#x231B; [=list/For each=] |prefetchRecord| of |document|'s [=Document/prefetch records=]:
     1. &#x231B; If |prefetchRecord|'s [=prefetch record/initiator=] is not `"speculation-rules"`, then [=iteration/continue=].
     1. &#x231B; [=Assert=]: |prefetchRecord|'s [=prefetch record/state=] is not `"canceled"`.
-    1. &#x231B; If no element of |prefetchCandidates| [=prefetch candidate/continues=] |prefetchRecord|, then [=prefetch record/cancel and discard=] |prefetchRecord|.
+    1. &#x231B; If no element of |prefetchCandidates| [=prefetch candidate/continues=] |prefetchRecord|, then [=prefetch record/cancel and discard=] |prefetchRecord| given |document|.
   1. End the [=synchronous section=], continuing the remaining steps [=in parallel=].
   1. [=list/For each=] |prefetchCandidate| of |prefetchCandidates|:
     1. The user agent may run the following steps:

--- a/speculation-rules.bs
+++ b/speculation-rules.bs
@@ -37,6 +37,9 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
 spec: nav-speculation; urlPrefix: prefetch.html
   type: dfn
     text: prefetch; url: prefetch
+    text: prefetch controller; url: prefetch-controller
+    text: abort; for: prefetch controller; url: prefetch-controller-abort
+    text: document; for: prefetch controller; url: prefetch-controller-document
     text: prefetch IP anonymization policy; url: prefetch-ip-anonymization-policy
     text: cross-origin prefetch IP anonymization policy; url: cross-origin-prefetch-ip-anonymization-policy
     text: origin; for: cross-origin prefetch IP anonymization policy; url: cross-origin-prefetch-ip-anonymization-policy-origin
@@ -236,6 +239,18 @@ A <dfn>prerender candidate</dfn> is a [=struct=] with the following [=struct/ite
 * <dfn for="prerender candidate">URL</dfn>, an [=URL=]
 * <dfn for="prerender candidate">referrer policy</dfn>, a [=referrer policy=]
 
+A <dfn>started prefetch</dfn> is a [=struct=] with the following [=struct/items=]:
+* <dfn for="started prefetch">candidate</dfn>, a [=prefetch candidate=]
+* <dfn for="started prefetch">controller</dfn>, a [=prefetch controller=]
+
+<div algorithm>
+  A [=started prefetch=] |startedPrefetch| is <dfn for="started prefetch">continued by</dfn> a [=prefetch candidate=] |prefetchCandidate| if the following are all true:
+  * |startedPrefetch|'s [=started prefetch/candidate=]'s [=prefetch candidate/URL=] equals |prefetchCandidate|'s [=prefetch candidate/URL=]
+  * |startedPrefetch|'s [=started prefetch/candidate=]'s [=prefetch candidate/anonymization policy=] equals |prefetchCandidate|'s [=prefetch candidate/anonymization policy=]
+</div>
+
+A {{Document}} has <dfn for=Document export>started prefetches</dfn>, which is a [=list=] of [=started prefetches=], initially empty.
+
 <div algorithm="consider speculation">
   To <dfn>consider speculation</dfn> for a [=document=] |document|:
 
@@ -253,15 +268,22 @@ A <dfn>prerender candidate</dfn> is a [=struct=] with the following [=struct/ite
     1. &#x231B; [=list/For each=] |rule| of |ruleSet|'s [=speculation rule set/prerender rules=]:
       1. &#x231B; [=list/For each=] |url| of |rule|'s [=speculation rule/URLs=]:
         1. &#x231B; [=list/Append=] a [=prerender candidate=] with [=prerender candidate/URL=] |url| and [=prerender candidate/referrer policy=] "`strict-origin-when-cross-origin`" to |prerenderCandidates|.
+  1. &#x231B; [=list/For each=] |startedPrefetch| of |document|'s [=Document/started prefetches=]:
+    1. &#x231B; If |startedPrefetch| is not [=started prefetch/continued by=] any element of |prefetchCandidates|, then:
+      1. &#x231B; [=prefetch controller/Abort=] |startedPrefetch|'s [=started prefetch/controller=].
+      1. &#x231B; [=list/Remove=] |startedPrefetch| from |document|'s [=Document/started prefetches=].
   1. End the [=synchronous section=], continuing the remaining steps [=in parallel=].
   1. [=list/For each=] |prefetchCandidate| of |prefetchCandidates|:
-    1. The user agent may [=prefetch=] given |document|, |prefetchCandidate|'s [=prefetch candidate/URL=], |prefetchCandidate|'s [=prefetch candidate/referrer policy=] and |prefetchCandidate|'s [=prefetch candidate/anonymization policy=].
+    1. The user agent may run the following steps:
+      1. Let |prefetchController| be a new [=prefetch controller=] whose [=prefetch controller/document=] is |document|.
+      1. [=Prefetch=] given |document|, |prefetchCandidate|'s [=prefetch candidate/URL=], |prefetchCandidate|'s [=prefetch candidate/referrer policy=], |prefetchCandidate|'s [=prefetch candidate/anonymization policy=], and |prefetchController|.
+      1. [=list/Append=] a new [=started prefetch=] whose [=started prefetch/candidate=] is |prefetchCandidate| and [=started prefetch/controller=] is |prefetchController| to |document|'s [=Document/started prefetches=].
   1. [=list/For each=] |prerenderCandidate| of |prefetchCandidates|:
       1. The user agent may [=create a prerendering browsing context=] given |prerenderCandidate|'s [=prerender candidate/URL=], |prerenderCandidate|'s [=prerender candidate/referrer policy=] and |document|.
 </div>
 
 <p class="issue">
-  We should also notice removals and consider cancelling speculated actions.
+  We should also cancel speculated prerenders.
 </p>
 
 <p class="issue">

--- a/speculation-rules.bs
+++ b/speculation-rules.bs
@@ -37,9 +37,15 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
 spec: nav-speculation; urlPrefix: prefetch.html
   type: dfn
     text: prefetch; url: prefetch
-    text: prefetch controller; url: prefetch-controller
-    text: abort; for: prefetch controller; url: prefetch-controller-abort
-    text: document; for: prefetch controller; url: prefetch-controller-document
+    text: prefetch record; url: prefetch-record
+    text: prefetch records; for: Document; url: document-prefetch-records
+    for: prefetch record
+      text: URL; url: prefetch-record-url
+      text: referrer policy; url: prefetch-record-referrer-policy
+      text: anonymization policy; url: prefetch-record-anonymization-policy
+      text: initiator; url: prefetch-record-initiator
+      text: state; url: prefetch-record-state
+      text: cancel and discard; url: prefetch-record-cancel-and-discard
     text: prefetch IP anonymization policy; url: prefetch-ip-anonymization-policy
     text: cross-origin prefetch IP anonymization policy; url: cross-origin-prefetch-ip-anonymization-policy
     text: origin; for: cross-origin prefetch IP anonymization policy; url: cross-origin-prefetch-ip-anonymization-policy-origin
@@ -239,17 +245,13 @@ A <dfn>prerender candidate</dfn> is a [=struct=] with the following [=struct/ite
 * <dfn for="prerender candidate">URL</dfn>, an [=URL=]
 * <dfn for="prerender candidate">referrer policy</dfn>, a [=referrer policy=]
 
-A <dfn>started prefetch</dfn> is a [=struct=] with the following [=struct/items=]:
-* <dfn for="started prefetch">candidate</dfn>, a [=prefetch candidate=]
-* <dfn for="started prefetch">controller</dfn>, a [=prefetch controller=]
-
 <div algorithm>
-  A [=started prefetch=] |startedPrefetch| is <dfn for="started prefetch">continued by</dfn> a [=prefetch candidate=] |prefetchCandidate| if the following are all true:
-  * |startedPrefetch|'s [=started prefetch/candidate=]'s [=prefetch candidate/URL=] equals |prefetchCandidate|'s [=prefetch candidate/URL=]
-  * |startedPrefetch|'s [=started prefetch/candidate=]'s [=prefetch candidate/anonymization policy=] equals |prefetchCandidate|'s [=prefetch candidate/anonymization policy=]
+  A [=prefetch candidate=] |prefetchCandidate| <dfn for="prefetch candidate">continues</dfn> a [=prefetch record=] |prefetchRecord| if the following are all true:
+  * |prefetchRecord|'s [=prefetch record/initiator=] is `"speculation-rules"`
+  * |prefetchRecord|'s [=prefetch record/state=] is not `"canceled"`
+  * |prefetchRecord|'s [=prefetch record/URL=] equals |prefetchCandidate|'s [=prefetch candidate/URL=]
+  * |prefetchRecord|'s [=prefetch record/anonymization policy=] equals |prefetchCandidate|'s [=prefetch candidate/anonymization policy=]
 </div>
-
-A {{Document}} has <dfn for=Document export>started prefetches</dfn>, which is a [=list=] of [=started prefetches=], initially empty.
 
 <div algorithm="consider speculation">
   To <dfn>consider speculation</dfn> for a [=document=] |document|:
@@ -268,16 +270,15 @@ A {{Document}} has <dfn for=Document export>started prefetches</dfn>, which is a
     1. &#x231B; [=list/For each=] |rule| of |ruleSet|'s [=speculation rule set/prerender rules=]:
       1. &#x231B; [=list/For each=] |url| of |rule|'s [=speculation rule/URLs=]:
         1. &#x231B; [=list/Append=] a [=prerender candidate=] with [=prerender candidate/URL=] |url| and [=prerender candidate/referrer policy=] "`strict-origin-when-cross-origin`" to |prerenderCandidates|.
-  1. &#x231B; [=list/For each=] |startedPrefetch| of |document|'s [=Document/started prefetches=]:
-    1. &#x231B; If |startedPrefetch| is not [=started prefetch/continued by=] any element of |prefetchCandidates|, then:
-      1. &#x231B; [=prefetch controller/Abort=] |startedPrefetch|'s [=started prefetch/controller=].
-      1. &#x231B; [=list/Remove=] |startedPrefetch| from |document|'s [=Document/started prefetches=].
+  1. &#x231B; [=list/For each=] |prefetchRecord| of |document|'s [=Document/prefetch records=]:
+    1. &#x231B; If |prefetchRecord|'s [=prefetch record/initiator=] is not `"speculation-rules"`, then [=iteration/continue=].
+    1. &#x231B; [=Assert=]: |prefetchRecord|'s [=prefetch record/state=] is not `"canceled"`.
+    1. &#x231B; If no element of |prefetchCandidates| [=prefetch candidate/continues=] |prefetchRecord|, then [=prefetch record/cancel and discard=] |prefetchRecord|.
   1. End the [=synchronous section=], continuing the remaining steps [=in parallel=].
   1. [=list/For each=] |prefetchCandidate| of |prefetchCandidates|:
     1. The user agent may run the following steps:
-      1. Let |prefetchController| be a new [=prefetch controller=] whose [=prefetch controller/document=] is |document|.
-      1. [=list/Append=] a new [=started prefetch=] whose [=started prefetch/candidate=] is |prefetchCandidate| and [=started prefetch/controller=] is |prefetchController| to |document|'s [=Document/started prefetches=].
-      1. [=Prefetch=] given |document|, |prefetchCandidate|'s [=prefetch candidate/URL=], |prefetchCandidate|'s [=prefetch candidate/referrer policy=], |prefetchCandidate|'s [=prefetch candidate/anonymization policy=], and |prefetchController|.
+      1. Let |prefetchRecord| be a new [=prefetch record=] whose [=prefetch record/URL=] is |prefetchCandidate|'s [=prefetch candidate/URL=], [=prefetch record/referrer policy=] is |prefetchCandidate|'s [=prefetch candidate/referrer policy=], [=prefetch record/anonymization policy=] is |prefetchCandidate|'s [=prefetch candidate/anonymization policy=], and [=prefetch record/initiator=] is `"speculation-rules"`.
+      1. [=Prefetch=] given |document| and |prefetchRecord|.
   1. [=list/For each=] |prerenderCandidate| of |prefetchCandidates|:
       1. The user agent may [=create a prerendering browsing context=] given |prerenderCandidate|'s [=prerender candidate/URL=], |prerenderCandidate|'s [=prerender candidate/referrer policy=] and |document|.
 </div>

--- a/speculation-rules.bs
+++ b/speculation-rules.bs
@@ -43,7 +43,7 @@ spec: nav-speculation; urlPrefix: prefetch.html
       text: URL; url: prefetch-record-url
       text: referrer policy; url: prefetch-record-referrer-policy
       text: anonymization policy; url: prefetch-record-anonymization-policy
-      text: initiator; url: prefetch-record-initiator
+      text: label; url: prefetch-record-label
       text: state; url: prefetch-record-state
       text: cancel and discard; url: prefetch-record-cancel-and-discard
     text: prefetch IP anonymization policy; url: prefetch-ip-anonymization-policy
@@ -247,7 +247,7 @@ A <dfn>prerender candidate</dfn> is a [=struct=] with the following [=struct/ite
 
 <div algorithm>
   A [=prefetch candidate=] |prefetchCandidate| <dfn for="prefetch candidate">continues</dfn> a [=prefetch record=] |prefetchRecord| if the following are all true:
-  * |prefetchRecord|'s [=prefetch record/initiator=] is `"speculation-rules"`
+  * |prefetchRecord|'s [=prefetch record/label=] is `"speculation-rules"`
   * |prefetchRecord|'s [=prefetch record/state=] is not `"canceled"`
   * |prefetchRecord|'s [=prefetch record/URL=] equals |prefetchCandidate|'s [=prefetch candidate/URL=]
   * |prefetchRecord|'s [=prefetch record/anonymization policy=] equals |prefetchCandidate|'s [=prefetch candidate/anonymization policy=]
@@ -271,13 +271,13 @@ A <dfn>prerender candidate</dfn> is a [=struct=] with the following [=struct/ite
       1. &#x231B; [=list/For each=] |url| of |rule|'s [=speculation rule/URLs=]:
         1. &#x231B; [=list/Append=] a [=prerender candidate=] with [=prerender candidate/URL=] |url| and [=prerender candidate/referrer policy=] "`strict-origin-when-cross-origin`" to |prerenderCandidates|.
   1. &#x231B; [=list/For each=] |prefetchRecord| of |document|'s [=Document/prefetch records=]:
-    1. &#x231B; If |prefetchRecord|'s [=prefetch record/initiator=] is not `"speculation-rules"`, then [=iteration/continue=].
+    1. &#x231B; If |prefetchRecord|'s [=prefetch record/label=] is not `"speculation-rules"`, then [=iteration/continue=].
     1. &#x231B; [=Assert=]: |prefetchRecord|'s [=prefetch record/state=] is not `"canceled"`.
     1. &#x231B; If no element of |prefetchCandidates| [=prefetch candidate/continues=] |prefetchRecord|, then [=prefetch record/cancel and discard=] |prefetchRecord| given |document|.
   1. End the [=synchronous section=], continuing the remaining steps [=in parallel=].
   1. [=list/For each=] |prefetchCandidate| of |prefetchCandidates|:
     1. The user agent may run the following steps:
-      1. Let |prefetchRecord| be a new [=prefetch record=] whose [=prefetch record/URL=] is |prefetchCandidate|'s [=prefetch candidate/URL=], [=prefetch record/referrer policy=] is |prefetchCandidate|'s [=prefetch candidate/referrer policy=], [=prefetch record/anonymization policy=] is |prefetchCandidate|'s [=prefetch candidate/anonymization policy=], and [=prefetch record/initiator=] is `"speculation-rules"`.
+      1. Let |prefetchRecord| be a new [=prefetch record=] whose [=prefetch record/URL=] is |prefetchCandidate|'s [=prefetch candidate/URL=], [=prefetch record/referrer policy=] is |prefetchCandidate|'s [=prefetch candidate/referrer policy=], [=prefetch record/anonymization policy=] is |prefetchCandidate|'s [=prefetch candidate/anonymization policy=], and [=prefetch record/label=] is `"speculation-rules"`.
       1. [=Prefetch=] given |document| and |prefetchRecord|.
   1. [=list/For each=] |prerenderCandidate| of |prefetchCandidates|:
       1. The user agent may [=create a prerendering browsing context=] given |prerenderCandidate|'s [=prerender candidate/URL=], |prerenderCandidate|'s [=prerender candidate/referrer policy=] and |document|.


### PR DESCRIPTION
This defines a concept of a "prefetch controller" which can be threaded into the prefetch code to allow the underlying fetches to be aborted and which will prevent the prefetch from being served from the prefetch buffer. This combination means that a prefetch which isn't otherwise cacheable (e.g., because it has Cache-Control: no-store) won't be used due to the special rules that apply to prefetch.