### PR TITLE
Remove keying on referrer policy

### DIFF
--- a/prefetch.bs
+++ b/prefetch.bs
@@ -19,7 +19,7 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
   type: dfn
     urlPrefix: browsers.html
       text: browsing context scope origin; url: browsing-context-scope-origin
-      text: container; for: browsing context; url: bc-container 
+      text: container; for: browsing context; url: bc-container
       text: determine the origin; url: determining-the-origin
     urlPrefix: browsing-the-web.html
       text: history handling behavior; url: history-handling-behavior
@@ -134,7 +134,6 @@ Each {{Document}} has <dfn export for="Document">prefetch records</dfn>, which i
 
 A <dfn export>prefetch record</dfn> is a [=struct=] with the following [=struct/items=]:
 * <dfn export for="prefetch record">URL</dfn>, a [=URL=]
-* <dfn export for="prefetch record">referrer policy</dfn>, a [=referrer policy=]
 * <dfn export for="prefetch record">anonymization policy</dfn>, a [=prefetch IP anonymization policy=]
 * <dfn export for="prefetch record">label</dfn>, a [=string=]
 
@@ -172,17 +171,17 @@ The user agent may [=prefetch record/cancel and discard=] records from the [=Doc
     1. [=Assert=]: |document| is [=Document/fully active=].
     1. Let |currentTime| be the [=current high resolution time=] for the [=relevant global object=] of |document|.
     1. Let |expiryTime| be |currentTime| + 300000 (i.e., five minutes).
-    1. [=list/Remove=] all elements of |document|'s [=Document/prefetch records=] which have the same [=prefetch record/URL=] and [=prefetch record/referrer policy=] as |prefetchRecord| and whose [=prefetch record/state=] equals "`completed`".
+    1. [=list/Remove=] all elements of |document|'s [=Document/prefetch records=] which have the same [=prefetch record/URL=] as |prefetchRecord| and whose [=prefetch record/state=] equals "`completed`".
     1. Set |prefetchRecord|'s [=prefetch record/state=] to "`completed`" and [=prefetch record/expiry time=] to |expiryTime|.
 </div>
 
 <div algorithm="find a matching prefetch record">
-    To <dfn export>find a matching prefetch record</dfn> given a {{Document}} |document|, [=URL=] |url|, [=referrer policy=] |referrerPolicy| and [=sandboxing flag set=] |sandboxFlags|, perform the following steps.
+    To <dfn export>find a matching prefetch record</dfn> given a {{Document}} |document|, [=URL=] |url|, and [=sandboxing flag set=] |sandboxFlags|, perform the following steps.
 
     1. [=Assert=]: |document| is [=Document/fully active=].
     1. Let |currentTime| be the [=current high resolution time=] for the [=relevant global object=] of |document|.
     1. [=list/For each=] |record| of |document|'s [=Document/prefetch records=]:
-        1. If |record|'s [=prefetch record/URL=] is not equal to |url| or |record|'s [=prefetch record/referrer policy=] is not equal to |referrerPolicy|, then [=iteration/continue=].
+        1. If |record|'s [=prefetch record/URL=] is not equal to |url|, then [=iteration/continue=].
         1. If |record|'s [=prefetch record/state=] is not "`completed`", then [=iteration/continue=].
         1. If |record|'s [=prefetch record/sandboxing flag set=] is empty and |sandboxFlags| is not empty, then [=iteration/continue=].
 
@@ -320,7 +319,7 @@ Given this, the non-prefetch case becomes, with the small addition of prefetch l
     1. If |browsingContext|'s [=browsing context/container=] is non-null:
         1. If |browsingContext|'s [=browsing context/container=] has a [=browsing context scope origin=], then set |request|'s [=request/origin=] to that [=browsing context scope origin=].
         1. Set |request|'s [=request/destination=] to |browsingContext|'s [=browsing context/container=]'s [=Element/local name=].
-    1. Let |prefetchRecord| be the result of [=finding a matching prefetch record=] given |browsingContext|'s [=active document=], |request|'s [=request/URL=], |request|'s [=request/referrer policy=], and |sandboxFlags|.
+    1. Let |prefetchRecord| be the result of [=finding a matching prefetch record=] given |browsingContext|'s [=active document=], |request|'s [=request/URL=], and |sandboxFlags|.
 
         <div class="note">This step, and the following condition, is added by this specification.</div>
     1. If |prefetchRecord| is not null, then:
@@ -381,8 +380,6 @@ These algorithms are based on [=process a navigate fetch=].
 
         :  [=request/URL=]
         :: |prefetchRecord|'s [=prefetch record/URL=]
-        :  [=request/referrer policy=]
-        :: |prefetchRecord|'s [=prefetch record/referrer policy=]
         :  [=request/initiator=]
         :: "`prefetch`"
 
@@ -447,7 +444,7 @@ The <dfn>list of sufficiently strict speculative navigation referrer policies</d
 
     1. [=Assert=]: |prefetchRecord|'s [=prefetch record/URL=]'s [=url/scheme=] is an [=HTTP(S) scheme=].
     1. [=list/Append=] |prefetchRecord| to |document|'s [=Document/prefetch records=].
-    1. If |prefetchRecord|'s [=prefetch record/referrer policy=] is not in the [=list of sufficiently strict speculative navigation referrer policies=], then [=prefetch record/cancel and discard=] |prefetchRecord| given |document|, and return.
+    1. If |document|'s [=Document/policy container=]'s [=policy container/referrer policy=] is not in the [=list of sufficiently strict speculative navigation referrer policies=], then [=prefetch record/cancel and discard=] |prefetchRecord| given |document|, and return.
     1. Let |browsingContext| be |document|'s [=Document/browsing context=].
     1. Set |prefetchRecord|'s [=prefetch record/sandboxing flag set=] to the result of [=determining the creation sandboxing flags=] given |browsingContext| and |browsingContext|'s [=browsing context/container=].
     1. Let |isolationOrigin| be a new [=opaque origin=].
@@ -461,8 +458,6 @@ The <dfn>list of sufficiently strict speculative navigation referrer policies</d
 
         :  [=request/URL=]
         :: |prefetchRecord|'s [=prefetch record/URL=]
-        :  [=request/referrer policy=]
-        :: |prefetchRecord|'s [=prefetch record/referrer policy=]
         :  [=request/initiator=]
         :: "`prefetch`"
 

--- a/prerendering.bs
+++ b/prerendering.bs
@@ -199,6 +199,7 @@ spec: service-workers; urlPrefix: https://w3c.github.io/ServiceWorker/
 spec: nav-speculation; urlPrefix: prefetch.html
   type: dfn
     text: supports prefetch; url: supports-prefetch
+    text: list of sufficiently-strict speculative navigation referrer policies
 </pre>
 <pre class="biblio">
 {
@@ -252,49 +253,6 @@ spec: nav-speculation; urlPrefix: prefetch.html
 }
 </style>
 
-<h2 id="link-rel-prerender">Link type "<dfn attr-value for="link/rel"><code>prerender</code></dfn>"</h2>
-
-<em>The following section would be added as a new sub-section of [[HTML]]'s <a href="https://html.spec.whatwg.org/multipage/links.html#linkTypes">Link types</a> section. This should replace the prerender documentation in [[RESOURCE-HINTS]]</em>
-
-The <{link/rel/prerender}> keyword may be used with <{link}> elements. This keyword creates an <a spec=HTML>external resource link</a>. This keyword is <a spec=HTML>body-ok</a>.
-
-The appropriate times to <a spec=HTML>fetch and process the linked resource</a> for such a link are:
-
-<ul>
-  <li>When the <a spec=HTML>external resource link</a> is created on a <{link}> element that is already [=browsing-context connected=]</a>.</li>
-  <li>When the <a spec=HTML>external resource link</a>'s <{link}> element [=becomes browsing-context connected=].</li>
-  <li>When the <{link/href}> attribute is changed on the <{link}> element of an [=external resource link=] that is already [=browsing-context connected=].</li>
-  <li>When the <{link/referrerpolicy}> attribute's state is changed on the <{link}> element of an [=external resource link=] that is already [=browsing-context connected=].</li>
-</ul>
-
-<div algorithm="prerender-processing-model">
-  The <a spec=HTML>fetch and process the linked resource</a> algorithm for <{link/rel/prerender}> links, given a <{link}> element <var>el</var>, is as follows:
-
-  1. If |el|'s <{link/href}> attribute's value is the empty string, then return.
-
-  1. [=Parse a URL=] given |el|'s <{link/href}> attribute, relative to |el|'s [=Node/node document=]. If that fails, then return. Otherwise, let |url| be the [=resulting URL record=].
-
-  1. If |url|'s [=url/scheme=] is not an [=HTTP(S) scheme=], then return.
-
-  1. Let |referrerPolicy| be  the current state of |el|'s <{link/referrerpolicy}> attribute.
-
-  1. If |url|'s [=url/origin=] is not [=same origin=] with |el|'s [=Node/node document=]'s [=Document/origin=], then:
-
-    1. If the [=list of sufficiently-strict speculative navigation referrer policies=] does not [=list/contain=] |referrerPolicy|, then return.
-
-  1. [=Create a prerendering browsing context=] with |url|, |referrerPolicy|, and |el|'s [=Node/node document=].
-</div>
-
-A user agent must not <a spec=HTML lt="delays the load event">delay the load event</a> of the <{link}> element's [=Node/node document=] for this link type.
-
-<p class="note">Note that this link type does not fire {{HTMLElement/error}} or {{HTMLElement/load}} events, unlike many other link types that create <a spec=HTML>external resource links</a>.
-
-The <dfn>list of sufficiently-strict speculative navigation referrer policies</dfn> is a [=list=] containing the following subset of [=referrer policies=]: the empty string, "`strict-origin-when-cross-origin`", "`strict-origin`", "`same-origin`", "`no-referrer`".
-
-<h2 id="speculation-rules">Speculation rules</h2>
-
-It is anticipated that prerendering will be triggered using <a href="speculation-rules.html">speculation rules</a>.
-
 <h2 id="prerendering-bcs">Prerendering browsing context infrastructure</h2>
 
 <h3 id="document-prerendering">Extensions to the {{Document}} interface</h3>
@@ -341,7 +299,7 @@ The <dfn attribute for="Document">prerendering</dfn> getter steps are to return 
 
 A [=prerendering browsing context=] is <dfn for="prerendering browsing context">empty</dfn> if the only entry in its [=session history=] is the initial `about:blank` {{Document}}.
 
-Every {{Document}} has a <dfn for="Document">prerendering browsing contexts map</dfn>, which is an [=ordered map=] of ([=URL=], [=referrer policy=]) [=tuples=] to [=prerendering browsing contexts=]. This is used to fulfill [=navigate|navigations=] to a given URL by instead [=prerendering browsing context/activating=] the corresponding prerendering browsing context.
+Every {{Document}} has a <dfn for="Document">prerendering browsing contexts map</dfn>, which is an [=ordered map=] of [=URLs=] to [=prerendering browsing contexts=]. This is used to fulfill [=navigate|navigations=] to a given URL by instead [=prerendering browsing context/activating=] the corresponding prerendering browsing context.
 
 Every {{Document}} has a <dfn for="Document">post-prerendering activation steps list</dfn>, which is a [=list=] where each [=list/item=] is a series of algorithm steps. For convenience, we define the <dfn for="platform object">post-prerendering activation steps list</dfn> for any platform object |platformObject| as:
 
@@ -388,11 +346,11 @@ Every {{Document}} has an <dfn for="Document">activation start time</dfn>, which
 </div>
 
 <div algorithm="create a prerendering browsing context">
-  To <dfn export>create a prerendering browsing context</dfn> given a [=URL=] |startingURL|, a [=referrer policy=] |referrerPolicy|, and a {{Document}} |referrerDoc|:
+  To <dfn export>create a prerendering browsing context</dfn> given a [=URL=] |startingURL| and a {{Document}} |referrerDoc|:
 
   1. [=Assert=]: |startingURL|'s [=url/scheme=] is an [=HTTP(S) scheme=].
 
-  1. If |referrerDoc|'s [=Document/prerendering browsing contexts map=][(|startingURL|, |referrerPolicy|)] [=map/exists=], then return.
+  1. If |referrerDoc|'s [=Document/prerendering browsing contexts map=][|startingURL|] [=map/exists=], then return.
 
   1. Let |bc| be the result of [=creating a new top-level browsing context=].
 
@@ -402,7 +360,7 @@ Every {{Document}} has an <dfn for="Document">activation start time</dfn>, which
 
     1. Set |bc|'s [=browsing context/loading mode=] to "`uncredentialed-prerender`".
 
-    1. [=Assert=]: The [=list of sufficiently-strict speculative navigation referrer policies=] [=list/contains=] |referrerPolicy|.
+    1. If |referrerDoc|'s [=Document/policy container=]'s [=policy container/referrer policy=] is not in the [=list of sufficiently-strict speculative navigation referrer policies=], then return. (No prerendering is performed.)
 
   1. Set |referrerDoc|'s [=Document/prerendering browsing contexts map=][|startingURL|] to |bc|.
 
@@ -410,9 +368,7 @@ Every {{Document}} has an <dfn for="Document">activation start time</dfn>, which
 
      <p class="note">As with regular [=browsing contexts=], the [=prerendering browsing context=] can be [=discarded=] for any reason, for example if it becomes unresponsive, performs a restricted operation, or if the user agent believes prerendering takes too much resources.
 
-  1. Let |request| be a new [=request=] whose [=request/URL=] is |startingURL| and [=request/referrer policy=] is |referrerPolicy|.
-
-  1. [=Navigate=] |bc| to |request| with the [=source browsing context=] set to |referrerDoc|'s [=Document/browsing context=].
+  1. [=Navigate=] |bc| to |startingURL| with the [=source browsing context=] set to |referrerDoc|'s [=Document/browsing context=].
 </div>
 
 <div algorithm>
@@ -526,7 +482,7 @@ Every {{Document}} has an <dfn for="Document">activation start time</dfn>, which
       * |historyHandling| is "`default`" or "`replace`"
       * |navigationType| is "`other`"
       * |request|'s [=request/method=] is \``GET`\`
-      * |browsingContext|'s [=active document=]'s [=Document/prerendering browsing contexts map=][(|request|'s [=request/URL=], |request|'s [=request/referrer policy=])] [=map/exists=] and is not [=prerendering browsing context/empty=]
+      * |browsingContext|'s [=active document=]'s [=Document/prerendering browsing contexts map=][|request|'s [=request/URL=]] [=map/exists=] and is not [=prerendering browsing context/empty=]
       * The result of calling [=should navigation request of type be blocked by content security policy?=] given |request| and <var ignore>navigationType</var> is "`Allowed`".
 
         <p class="note">There is no need for an additional CSP check for the response, see [=navigate-to=].
@@ -542,7 +498,7 @@ Patch the [=navigate=] algorithm to allow the [=prerendering browsing context/ac
 
   1. If |resource| is a [=request=] and we [=can activate a prerender=] given |browsingContext|, |historyHandling|, <var ignore>navigationType</var>, and |resource|, then:
 
-    1. Let |successorBC| be |browsingContext|'s [=active document=]'s [=Document/prerendering browsing contexts map=][(|resource|'s [=request/URL=], |resource|'s [=request/referrer policy=])].
+    1. Let |successorBC| be |browsingContext|'s [=active document=]'s [=Document/prerendering browsing contexts map=][|resource|'s [=request/URL=]].
 
     1. Wait until all navigation attempts of |successorBC| have been [=navigate/mature|matured=].
 
@@ -576,7 +532,7 @@ Patch the [=process a navigate fetch=] algorithm like so:
 
     1. Set |browsingContext|'s [=browsing context/loading mode=] to "`uncredentialed-prerender`".
 
-    1. If the [=list of sufficiently-strict speculative navigation referrer policies=] does not [=list/contain=] <var ignore>request</var>'s [=referrer policy=], then:
+    1. If the [=list of sufficiently-strict speculative navigation referrer policies=] does not [=list/contain=] <var ignore>request</var>'s [=request/referrer policy=], then:
 
       1. [=Assert=]: |response| is not null.
 

--- a/speculation-rules.bs
+++ b/speculation-rules.bs
@@ -44,7 +44,6 @@ spec: nav-speculation; urlPrefix: prefetch.html
     text: prefetch records; for: Document; url: document-prefetch-records
     for: prefetch record
       text: URL; url: prefetch-record-url
-      text: referrer policy; url: prefetch-record-referrer-policy
       text: anonymization policy; url: prefetch-record-anonymization-policy
       text: label; url: prefetch-record-label
       text: state; url: prefetch-record-state
@@ -247,14 +246,12 @@ Periodically, for any [=document=] |document|, the user agent may [=queue a glob
 </p>
 
 A <dfn>prefetch candidate</dfn> is a [=struct=] with the following [=struct/items=]:
-* <dfn for="prefetch candidate">URL</dfn>, an [=URL=]
-* <dfn for="prefetch candidate">referrer policy</dfn>, a [=referrer policy=]
+* <dfn for="prefetch candidate">URL</dfn>, a [=URL=]
 * <dfn for="prefetch candidate">anonymization policy</dfn>, a [=prefetch IP anonymization policy=]
 
 A <dfn>prerender candidate</dfn> is a [=struct=] with the following [=struct/items=]:
-* <dfn for="prerender candidate">URL</dfn>, an [=URL=]
+* <dfn for="prerender candidate">URL</dfn>, a [=URL=]
 * <dfn for="prerender candidate">target browsing context name hint</dfn>, a [=valid browsing context name or keyword=] or null
-* <dfn for="prerender candidate">referrer policy</dfn>, a [=referrer policy=]
 
 <div algorithm>
   A [=prefetch candidate=] |prefetchCandidate| <dfn for="prefetch candidate">continues</dfn> a [=prefetch record=] |prefetchRecord| if the following are all true:
@@ -277,10 +274,10 @@ A <dfn>prerender candidate</dfn> is a [=struct=] with the following [=struct/ite
       1. &#x231B; Let |anonymizationPolicy| be null.
       1. &#x231B; If |rule|'s [=speculation rule/requirements=] [=set/contains=] "`anonymous-client-ip-when-cross-origin`", set |anonymizationPolicy| to a [=cross-origin prefetch IP anonymization policy=] whose [=cross-origin prefetch IP anonymization policy/origin=] is |document|'s [=Document/origin=].
       1. &#x231B; [=list/For each=] |url| of |rule|'s [=speculation rule/URLs=]:
-        1. &#x231B; [=list/Append=] a [=prefetch candidate=] with [=prefetch candidate/URL=] |url|, [=prefetch candidate/referrer policy=] "`strict-origin-when-cross-origin`", and [=prefetch candidate/anonymization policy=] |anonymizationPolicy| to |prefetchCandidates|.
+        1. &#x231B; [=list/Append=] a [=prefetch candidate=] with [=prefetch candidate/URL=] |url| and [=prefetch candidate/anonymization policy=] |anonymizationPolicy| to |prefetchCandidates|.
     1. &#x231B; [=list/For each=] |rule| of |ruleSet|'s [=speculation rule set/prerender rules=]:
       1. &#x231B; [=list/For each=] |url| of |rule|'s [=speculation rule/URLs=]:
-        1. &#x231B; Let |prerenderCandidate| be a new [=prerender candidate=] whose [=prerender candidate/URL=] is |url|, [=prerender candidate/referrer policy=] is "`strict-origin-when-cross-origin`", and [=prerender candidate/target browsing context name hint=] is |rule|'s [=speculation rule/target browsing context name hint=].
+        1. &#x231B; Let |prerenderCandidate| be a new [=prerender candidate=] whose [=prerender candidate/URL=] is |url| and [=prerender candidate/target browsing context name hint=] is |rule|'s [=speculation rule/target browsing context name hint=].
         1. &#x231B; [=list/Append=] |prerenderCandidate| to |prerenderCandidates|.
   1. &#x231B; [=list/For each=] |prefetchRecord| of |document|'s [=Document/prefetch records=]:
     1. &#x231B; If |prefetchRecord|'s [=prefetch record/label=] is not "`speculation-rules`", then [=iteration/continue=].
@@ -289,10 +286,10 @@ A <dfn>prerender candidate</dfn> is a [=struct=] with the following [=struct/ite
   1. End the [=synchronous section=], continuing the remaining steps [=in parallel=].
   1. [=list/For each=] |prefetchCandidate| of |prefetchCandidates|:
     1. The user agent may run the following steps:
-      1. Let |prefetchRecord| be a new [=prefetch record=] whose [=prefetch record/URL=] is |prefetchCandidate|'s [=prefetch candidate/URL=], [=prefetch record/referrer policy=] is |prefetchCandidate|'s [=prefetch candidate/referrer policy=], [=prefetch record/anonymization policy=] is |prefetchCandidate|'s [=prefetch candidate/anonymization policy=], and [=prefetch record/label=] is "`speculation-rules`".
+      1. Let |prefetchRecord| be a new [=prefetch record=] whose [=prefetch record/URL=] is |prefetchCandidate|'s [=prefetch candidate/URL=], [=prefetch record/anonymization policy=] is |prefetchCandidate|'s [=prefetch candidate/anonymization policy=], and [=prefetch record/label=] is "`speculation-rules`".
       1. [=Prefetch=] given |document| and |prefetchRecord|.
   1. [=list/For each=] |prerenderCandidate| of |prefetchCandidates|:
-      1. The user agent may [=create a prerendering browsing context=] given |prerenderCandidate|'s [=prerender candidate/URL=], |prerenderCandidate|'s [=prerender candidate/referrer policy=] and |document|.
+      1. The user agent may [=create a prerendering browsing context=] given |prerenderCandidate|'s [=prerender candidate/URL=] and |document|.
 
          The user agent can use |prerenderCandidate|'s [=prerender candidate/target browsing context name hint=] as a hint to their implementation of the [=create a prerendering browsing context=] algorithm. This hint indicates that the web developer expects the eventual [=prerendering browsing context/activate|activation=] of the created browsing context to be in place of a particular predecessor browsing context: the one that would be chosen by the invoking the [=rules for choosing a browsing context=] given |prerenderCandidate|'s [=prerender candidate/target browsing context name hint=] and |document|'s [=Document/browsing context=].
 
@@ -301,10 +298,6 @@ A <dfn>prerender candidate</dfn> is a [=struct=] with the following [=struct/ite
 
 <p class="issue">
   We should also cancel speculated prerenders.
-</p>
-
-<p class="issue">
-  We should revisit the [=referrer policies=] used here.
 </p>
 
 <h2 id="security-considerations">Security considerations</h2>


### PR DESCRIPTION
This also removes the `<link rel="prerender">` specification, since that was speculative and ended up not being implemented. And it solves the issue about prefetch/prerender candidates from speculation rules using hard-coded default referrer policies; instead they now use the document's referrer policy.

Some work probably remains about properly restricting preloading to sufficiently-strict referrer policies. Right now that is checked when going cross-origin, which might be enough?

Closes #18.