### PR TITLE
Document rules: introduce "where" key which accepts an array of conditions

### DIFF
--- a/triggers.md
+++ b/triggers.md
@@ -198,25 +198,27 @@ In addition to list rules, we envision _document_ rules, denoted by `"source": "
 The URL can be compared against [URL patterns][urlpattern] (parsed relative to the same base URL as URLs in list rules).
 
 <dl>
-<dt><code>"href_matches": [...]</code></dt>
-<dd>requires that the link URL match at least one pattern from the list</dd>
+<dt><code>"href_matches": ...</code></dt>
+<dd>requires that the link URL match the provided pattern (or any of the provided patterns, if there are multiple)</dd>
 </dl>
 
 The link element itself can also be [matched][selector-match] using [CSS selectors][selectors].
 
 <dl>
-<dt><code>"selector_matches": [...]</code></dt>
-<dd>requires that the link element match at least one selector from the list</dd>
+<dt><code>"selector_matches": ...</code></dt>
+<dd>requires that the link element match the provided selector (or any of the provided selectors, if there are multiple)</dd>
 </dl>
 
-Any of these simple conditions can be negated.
+Any of these simple conditions can be negated and combined with conjunction and disjunction.
 
 <dl>
 <dt><code>"not": {...}</code></dt>
 <dd>requires that the condition not match</dd>
+<dt><code>"and": [...]</code></dt>
+<dd>requires that every condition in the list match</dd>
+<dt><code>"or": [...]</code></dt>
+<dd>requires that at least one condition in the list match</dd>
 </dl>
-
-In the future, a more complete boolean algebra could be added if needed.
 
 An example of using these would be the following, which marks up as safe-to-prerender all same-origin pages except those known to be problematic:
 
@@ -224,11 +226,11 @@ An example of using these would be the following, which marks up as safe-to-prer
 {
   "prerender": [
     {"source": "document",
-     "where": [
-       {"href_matches": ["/*"]},
-       {"not": {"href_matches": ["/logout"]}},
-       {"not": {"selector_matches": [".no-prerender"]}}
-     ],
+     "where": {"and": [
+       {"href_matches": "/*"},
+       {"not": {"href_matches": "/logout"}},
+       {"not": {"selector_matches": ".no-prerender"}}
+     ]},
      "score": 0.1}
   ]
 }

--- a/triggers.md
+++ b/triggers.md
@@ -238,6 +238,14 @@ An example of using these would be the following, which marks up as safe-to-prer
 
 Note how this example uses a low `"score"` value to indicate that, although these links are _safe_ to prerender, they aren't necessarily that important or likely to be clicked on. In such a case, the browser would likely use its own heuristics, e.g. only performing the prerender on pointer-down. Additionally, the web developer might combine this with a higher-scoring rule that indicates which URLs they suspect are likely, which the browser could prerender ahead of time.
 
+#### Alternatives
+
+There are a number of alternatives to this that were not selected, such as:
+
+* **Implicit `"and"` on conditions.** A straw poll suggested this wasn't obvious, and making this explicit made it easier to understand.
+* **A bespoke parsed expression syntax.** This has nice ergonomic properties for complex expressions, but expressions are expected to be fairly simple in practice. If strings like selectors and URL patterns might be controlled by an attacker, this would also potentially introduce injection vulnerabilities (along the lines of XSS and SQL injection), unless an even more cumbersome syntax (along the lines of prepared statements) were used. This would also generally be more difficult to programmatically manipulate, whereas keeping this in pure JSON allows existing JSON tooling in various languages (but most notably JavaScript and web browsers) to be manipulate it.
+* **Combining negation with conditions.** Given the desire to provide more general logic primitives, this would be somewhat surprising. Negation with a separate object is longer but not dramatically longer. In the case of CSS selectors, a shorter syntax for negation is already available even without support at this level (namely, the `:not(...)` pseudo-class).
+
 ### Handler URLs
 
 Another possible future extension, which would likely need to be restricted to same-origin URLs, could allow the actual URL to be preloaded to be different from the navigation URL (but on the same origin), until the navigation actually occurs. This could allow multiple possible destinations with a common "template" (e.g., product detail pages) to preload just the template. This preloaded page could then be used regardless of which product the user selects.

--- a/triggers.md
+++ b/triggers.md
@@ -198,20 +198,25 @@ In addition to list rules, we envision _document_ rules, denoted by `"source": "
 The URL can be compared against [URL patterns][urlpattern] (parsed relative to the same base URL as URLs in list rules).
 
 <dl>
-<dt><code>"if_href_matches": [...]</code></dt>
+<dt><code>"href_matches": [...]</code></dt>
 <dd>requires that the link URL match at least one pattern from the list</dd>
-<dt><code>"if_not_href_matches": [...]</code></dt>
-<dd>requires that the link URL not match any pattern from the list</dd>
 </dl>
 
 The link element itself can also be [matched][selector-match] using [CSS selectors][selectors].
 
 <dl>
-<dt><code>"if_selector_matches": [...]</code></dt>
+<dt><code>"selector_matches": [...]</code></dt>
 <dd>requires that the link element match at least one selector from the list</dd>
-<dt><code>"if_not_selector_matches": [...]</code></dt>
-<dd>requires that the link element not match any selector from the list</dd>
 </dl>
+
+Any of these simple conditions can be negated.
+
+<dl>
+<dt><code>"not": {...}</code></dt>
+<dd>requires that the condition not match</dd>
+</dl>
+
+In the future, a more complete boolean algebra could be added if needed.
 
 An example of using these would be the following, which marks up as safe-to-prerender all same-origin pages except those known to be problematic:
 
@@ -219,9 +224,11 @@ An example of using these would be the following, which marks up as safe-to-prer
 {
   "prerender": [
     {"source": "document",
-     "if_href_matches": ["/*"],
-     "if_not_href_matches": ["/logout"],
-     "if_not_selector_matches": [".no-prerender"],
+     "where": [
+       {"href_matches": ["/*"]},
+       {"not": {"href_matches": ["/logout"]}},
+       {"not": {"selector_matches": [".no-prerender"]}}
+     ],
      "score": 0.1}
   ]
 }


### PR DESCRIPTION
This isn't quite full boolean algebra, but addresses #160. It's tempting to go for a full parsed expression syntax but that introduces a fairly significant complexity, escaping, etc.