### PR TITLE
Describe how client hints should work in prerendering context

### DIFF
--- a/prerendering.bs
+++ b/prerendering.bs
@@ -696,8 +696,10 @@ To <dfn>add a new prerender Accept-CH cache entry</dfn> given a [=prerendering b
 <div algorithm="append client hints to request patch">
   Modify the <a spec=CLIENT-HINTS-INFRASTRUCTURE>append client hints to request</a> algorithm, by prepending the following steps before iterating over the |hintSet|:
 
-  1. Let |browsingContext| be |settingsObject|’s [=environment settings object/global object=]'s [=Window/browsing context=].
-    If |browsingContext| is a [=prerendering browsing context=], retrieve |prerender client hint set| in [=prerendering browsing context/prerender-scoped Accept-CH cache=], and then update the |hintSet| with |prerender client hint set|.
+  1. Let |browsingContext| be <var ignore>settingsObject</var>’s [=environment settings object/global object=]'s [=Window/browsing context=].
+    If |browsingContext| is a [=prerendering browsing context=], then:
+      1. Let |origin| be <var ignore>request</var>'s [=request/url=]'s [=url/origin=].
+      1. Set |hintSet| to the [=set/union=] of |hintSet| and |browsingContext|'s [=prerendering browsing context/prerender-scoped Accept-CH cache=][|origin|].
   
 </div>
 

--- a/prerendering.bs
+++ b/prerendering.bs
@@ -696,7 +696,7 @@ To <dfn>add a new prerender Accept-CH cache entry</dfn> given a [=prerendering b
 <div algorithm="append client hints to request patch">
   Modify the <a spec=CLIENT-HINTS-INFRASTRUCTURE>append client hints to request</a> algorithm, by prepending the following steps before iterating over the |hintSet|:
 
-  1. Let |browsingContext| be |settingsObject|’s [=global object=]'s [=browsing context=].
+  1. Let |browsingContext| be |settingsObject|’s [=environment settings object/global object=]'s [=Window/browsing context=].
     If |browsingContext| is a [=prerendering browsing context=], retrieve |prerender client hint set| in [=prerendering browsing context/prerender-scoped Accept-CH cache=], and then update the |hintSet| with |prerender client hint set|.
   
 </div>
@@ -705,8 +705,8 @@ To <dfn>add a new prerender Accept-CH cache entry</dfn> given a [=prerendering b
   Modify the <a spec=CLIENT-HINTS-INFRASTRUCTURE>update the Client Hints set</a> algorithm, by updating the last step.
 
   1. If |browsingContext| is a [=prerendering browsing context=],
-    [=add a new prerender Accept-CH cache entry=] with |response|'s [=url/origin=] and |settingsObject|'s [=environment settings object/client hints set=].
-    Otherwise, [=Add a new Accept-CH cache entry=] with |response|'s [=url/origin=] and |settingsObject|'s [=environment settings object/client hints set=].
+    [=add a new prerender Accept-CH cache entry=] with |response|'s [=response/url=]'s [=url/origin=] and |settingsObject|'s [=environment settings object/client hints set=].
+  1. Else [=add a new Accept-CH cache entry=] with |response|'s [=response/url=]'s [=url/origin=] and |settingsObject|'s [=environment settings object/client hints set=].
 
 </div>
 

--- a/prerendering.bs
+++ b/prerendering.bs
@@ -206,6 +206,10 @@ spec: RFC8941; urlPrefix: https://www.rfc-editor.org/rfc/rfc8941.html
     for: structured header
       text: list; url: name-lists
       text: token; url: name-tokens
+spec: client-hints-infrastructure; urlPrefix: https://wicg.github.io/client-hints-infrastructure
+  type: dfn
+    text: Accept-CH cache; url: accept-ch-cache
+    text: append client hints to request; url: abstract-opdef-append-client-hints-to-request
 </pre>
 <pre class="biblio">
 {
@@ -657,6 +661,22 @@ Extend the {{PerformanceNavigationTiming}} interface as follows:
 The <dfn attribute for="PerformanceNavigationTiming">activationStart</dfn> getter steps are:
 
 1. Return a {{DOMHighResTimeStamp}} with a time value equal to the [=current document=]'s [=Document/activation start time=].
+
+<h3 id="client hint cache">Interaction with Client Hint Cache</h3>
+
+We need to ensure that the [=Accept-CH cache=], which is owned by user agent as a global storage, is not modified while prerendering, but is properly updated after activation. The following modifications ensure this.
+
+Each [=prerendering browsing context=] has a <dfn for="prerendering browsing context">prerender-scoped Accept-CH cache</dfn>, which is an [=ordered map=] of [=origin=] to [=client hints sets=].
+
+This stores which client hints each origin has opted into receiving, until it can be copied to the global [=Accept-CH cache=] when [=prerendering browsing context/finalize activation|activation is finalized=].
+
+<div algorithm="append client hints to request patch">
+  Modify the <a spec=CLIENT-HINTS-INFRASTRUCTURE>append client hints to request</a> algorithm, by prepending the following steps before iterating over the |hintSet|:
+
+  1. Let |browsingContext| be |settingsObject|’s [=global object=]'s [=browsing context=].
+    If |browsingContext| is a [=prerendering browsing context=], retrieve |prerender client hint set| in [=prerendering browsing context/prerender-scoped Accept-CH cache=], and then update the |hintSet| with |prerender client hint set|.
+  
+</div>
 
 <h2 id="supports-loading-mode">The \`<dfn http-header><code>Supports-Loading-Mode</code></dfn>\` HTTP response header</h2>
 

--- a/prerendering.bs
+++ b/prerendering.bs
@@ -460,6 +460,10 @@ Every {{Document}} has an <dfn for="Document">activation start time</dfn>, which
 
     1. If |doc|'s [=Document/origin=] is the same as |origin|, then set |doc|'s [=Document/activation start time=] to the [=relative high resolution time=] for |unsafe time| and |doc|.
 
+    1. [=map/For each=] |origin| → |hintSet| in |bc|'s [=prerendering browsing context/prerender-scoped Accept-CH cache=]:
+      
+      1. [=Add a new Accept-CH cache entry=] to the [=Accept-CH cache=] with the |origin| and |hintSet|.
+
     1. [=Fire an event=] named {{Document/prerenderingchange}} at |doc|.
 
     1. [=list/For each=] |steps| in |doc|'s [=Document/post-prerendering activation steps list=]:

--- a/prerendering.bs
+++ b/prerendering.bs
@@ -673,7 +673,7 @@ The <dfn attribute for="PerformanceNavigationTiming">activationStart</dfn> gette
 
 1. Return a {{DOMHighResTimeStamp}} with a time value equal to the [=current document=]'s [=Document/activation start time=].
 
-<h3 id="client hint cache">Interaction with Client Hint Cache</h3>
+<h3 id="client-hint-cache">Interaction with Client Hint Cache</h3>
 
 We need to ensure that the [=Accept-CH cache=], which is owned by user agent as a global storage, is not modified while prerendering, but is properly updated after activation. The following modifications ensure this.
 

--- a/prerendering.bs
+++ b/prerendering.bs
@@ -209,7 +209,14 @@ spec: RFC8941; urlPrefix: https://www.rfc-editor.org/rfc/rfc8941.html
 spec: client-hints-infrastructure; urlPrefix: https://wicg.github.io/client-hints-infrastructure
   type: dfn
     text: Accept-CH cache; url: accept-ch-cache
+    text: add a new Accept-CH cache entry; url: add-a-new-accept-ch-cache-entry
     text: append client hints to request; url: abstract-opdef-append-client-hints-to-request
+    text: client hints token; url: client-hints-token-definition
+    text: client hints set; url: client-hints-set
+    text: update the Client Hints set; url: abstract-opdef-update-the-client-hints-set
+    for: environment settings object
+      text: client hints set; url: environment-settings-object-client-hints-set
+
 </pre>
 <pre class="biblio">
 {
@@ -670,12 +677,33 @@ Each [=prerendering browsing context=] has a <dfn for="prerendering browsing con
 
 This stores which client hints each origin has opted into receiving, until it can be copied to the global [=Accept-CH cache=] when [=prerendering browsing context/finalize activation|activation is finalized=].
 
+<div algorithm>
+
+To <dfn>add a new prerender Accept-CH cache entry</dfn> given a [=prerendering browsing context=] |bc|, an [=origin=] |origin|, and a [=client hints set=] |hintSet|:
+
+  1. Let |cache| be |bc|'s [=prerendering browsing context/prerender-scoped Accept-CH cache=].
+
+  1. [=map/set=] |cache|[|origin|] to |hintSet|.
+
+
+<p class="note">This is similar to [=add a new Accept-CH cache entry=].</p>
+</div>
+
 <div algorithm="append client hints to request patch">
   Modify the <a spec=CLIENT-HINTS-INFRASTRUCTURE>append client hints to request</a> algorithm, by prepending the following steps before iterating over the |hintSet|:
 
   1. Let |browsingContext| be |settingsObject|’s [=global object=]'s [=browsing context=].
     If |browsingContext| is a [=prerendering browsing context=], retrieve |prerender client hint set| in [=prerendering browsing context/prerender-scoped Accept-CH cache=], and then update the |hintSet| with |prerender client hint set|.
   
+</div>
+
+<div algorithm="update the Client Hints set patch">
+  Modify the <a spec=CLIENT-HINTS-INFRASTRUCTURE>update the Client Hints set</a> algorithm, by updating the last step.
+
+  1. If |browsingContext| is a [=prerendering browsing context=],
+    [=add a new prerender Accept-CH cache entry=] with |response|'s [=url/origin=] and |settingsObject|'s [=environment settings object/client hints set=].
+    Otherwise, [=Add a new Accept-CH cache entry=] with |response|'s [=url/origin=] and |settingsObject|'s [=environment settings object/client hints set=].
+
 </div>
 
 <h2 id="supports-loading-mode">The \`<dfn http-header><code>Supports-Loading-Mode</code></dfn>\` HTTP response header</h2>

--- a/prerendering.bs
+++ b/prerendering.bs
@@ -706,9 +706,10 @@ To <dfn>add a new prerender Accept-CH cache entry</dfn> given a [=prerendering b
 <div algorithm="update the Client Hints set patch">
   Modify the <a spec=CLIENT-HINTS-INFRASTRUCTURE>update the Client Hints set</a> algorithm, by updating the last step.
 
-  1. If |browsingContext| is a [=prerendering browsing context=],
-    [=add a new prerender Accept-CH cache entry=] with |response|'s [=response/url=]'s [=url/origin=] and |settingsObject|'s [=environment settings object/client hints set=].
-  1. Else [=add a new Accept-CH cache entry=] with |response|'s [=response/url=]'s [=url/origin=] and |settingsObject|'s [=environment settings object/client hints set=].
+  1. Let |origin| be <var ignore>response</var>'s [=response/url=]'s [=url/origin=].
+  1. Let |hintSet| be <var ignore>settingsObject</var>'s [=environment settings object/client hints set=].
+  1. If |browsingContext| is a [=prerendering browsing context=], [=add a new prerender Accept-CH cache entry=] with |browsingContext|, |origin| and |hintSet|.
+  1. Otherwise, [=add a new Accept-CH cache entry=] with |origin| and |hintSet|.
 
 </div>
 


### PR DESCRIPTION
Context:
Since Accept-CH cache is a global instance, prerender pages should not be able to modify it until users activate these pages.

The proposal is that prerender pages maintain their own caches, and use them to:

- store the opt-in sent with prerender repopnse,  
- update the following prerender fetch requests by appending opt-in headers  

Changes to Accept-CH cache will be exected upon prerender activation.