### PR TITLE
Add specification for Web Locks API

### DIFF
--- a/prerendering.bs
+++ b/prerendering.bs
@@ -181,6 +181,10 @@ spec: speech-api; urlPrefix: https://wicg.github.io/speech-api/
     text: start(); url: dom-speechrecognition-start
     text: stop(); url: dom-speechrecognition-stop
     text: abort(); url: dom-speechrecognition-abort
+spec: web-locks; urlPrefix: https://w3c.github.io/web-locks/
+  type: method; for: LockManager
+    text: request(); url:dom-lockmanager-request
+    text: query(); url:dom-lockmanager-query
 spec: service-workers; urlPrefix: https://w3c.github.io/ServiceWorker/
   type: interface
     text: ServiceWorkerRegistration; url: serviceworkerregistration-interface
@@ -950,6 +954,10 @@ Add {{[DelayWhilePrerendering]}} to {{CredentialsContainer/get()}}, {{Credential
 Add {{[DelayWhilePrerendering]}} to	{{SpeechSynthesis/speak(utterance)}}, {{SpeechSynthesis/cancel()}},	{{SpeechSynthesis/pause()}}, and {{SpeechSynthesis/resume()}}.
 
 Add {{[DelayWhilePrerendering]}} to {{SpeechRecognition/start()}}, {{SpeechRecognition/stop()}}, and {{SpeechRecognition/abort()}}.
+
+<h4 id="web-locks-patch">Web Locks API</h4>
+
+Add {{[DelayWhilePrerendering]}} to {{LockManager/request()}} and {{LockManager/query()}}.
 
 <h3 id="implicitly-restricted">Implicitly restricted APIs</h3>
 


### PR DESCRIPTION
WebLocks API's request() and query() methods return promises, and prerender can safely defer them.
This PR describes how this API should work in the prerendering context.