### PR TITLE
Implement multi-file spec pull request preview on GitHub Actions.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,5 @@
 name: Build
 on:
-  pull_request:
-    branches:
-    - main
   push:
     branches:
     - main
@@ -11,11 +8,11 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Build
       run: make ci
     - name: Deploy
-      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      if: ${{ github.ref == 'refs/heads/main' }}
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -88,11 +88,11 @@ jobs:
           console.log(body);
           const issue = {...context.repo, issue_number: context.issue.number};
           const comments = await github.paginate(
-              github.rest.issues.listComments.endpoint.merge({...issue});
+              github.rest.issues.listComments.endpoint.merge({...issue}));
           let comment = comments.find(
               comment => comment.body.includes("<!-- preview-magic-74656 -->"));
           if (comment) {
             await github.rest.issues.updateComment({...issue, comment_id: comment.id, body});
           } else {
-            await github.rest.issues.createComment({...issue, body})
+            await github.rest.issues.createComment({...issue, body});
           }

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -67,6 +67,7 @@ jobs:
         glob: "**/*.html"
         destination: "${{ env.GCS_BASE }}"
         parent: false
+        gzip: false
         headers: |-
           content-type: text/html; charset=UTF-8
           content-encoding: br

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -55,7 +55,7 @@ jobs:
     - name: Compress
       shell: bash
       run: |
-        sudo apt-get install -y brotli
+        which brotli >/dev/null || sudo apt-get install -y brotli
         mkdir -p out-gcs/diff
         for head_file in $(find out-head -name '*.html'); do
           brotli "$head_file" -o out-gcs/"${head_file#*/}"

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -26,12 +26,12 @@ jobs:
     - name: Build (head)
       run: |
         make ci
-        cp -rv out out-head
+        mv out out-head
     - name: Build (base)
       run: |
         git checkout HEAD^
         make ci
-        cp -rv out out-base
+        mv out out-base
     - name: Checkout w3c/htmldiff-ui
       uses: actions/checkout@v3
       with:
@@ -46,7 +46,11 @@ jobs:
           base_file=out-base/"${head_file#*/}"
           diff_file=out-diff/"${head_file#*/}"
           if [[ -e "$base_file" ]]; then
-            perl htmldiff-ui/htmldiff.pl "$base_file" "$head_file" "$diff_file"
+            if cmp -q "$head_file" "$base_file"; then
+              rm "$base_file" "$head_file"
+            else
+              perl htmldiff-ui/htmldiff.pl "$base_file" "$head_file" "$diff_file"
+            fi
           fi
         done
     - name: Compress

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -71,7 +71,7 @@ jobs:
         headers: |-
           content-type: text/html; charset=UTF-8
           content-encoding: br
-          cache-control: no-transform
+          cache-control: no-transform, max-age=30
     - name: Post comment
       uses: actions/github-script@v6
       with:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -70,6 +70,7 @@ jobs:
         headers: |-
           content-type: text/html; charset=UTF-8
           content-encoding: br
+          cache-control: no-transform
     - name: Post comment
       uses: actions/github-script@v6
       with:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -46,7 +46,7 @@ jobs:
           base_file=out-base/"${head_file#*/}"
           diff_file=out-diff/"${head_file#*/}"
           if [[ -e "$base_file" ]]; then
-            if cmp -q "$head_file" "$base_file"; then
+            if cmp -s "$head_file" "$base_file"; then
               rm "$base_file" "$head_file"
             else
               perl htmldiff-ui/htmldiff.pl "$base_file" "$head_file" "$diff_file"

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -68,8 +68,8 @@ jobs:
         destination: "${{ env.GCS_BASE }}"
         parent: false
         headers: |-
-          Content-Type: text/html; charset=UTF-8
-          Content-Encoding: br
+          content-type: text/html; charset=UTF-8
+          content-encoding: br
     - name: Post comment
       uses: actions/github-script@v6
       with:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -10,6 +10,7 @@ jobs:
     permissions:
       contents: 'read'
       id-token: 'write'
+      issues: 'write'
     env:
       GCS_BASE: "spec-previews/${{ github.repository }}/pull/${{ github.event.number }}"
     steps:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,98 @@
+name: Preview
+on:
+  pull_request:
+    paths:
+    - '**.bs'
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+      issues: 'write'
+      pull-requests: 'write'
+    env:
+      GCS_BASE: "spec-previews/${{ github.repository }}/pull/${{ github.event.number }}"
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 2
+    - name: Authenticate to Google Cloud
+      uses: google-github-actions/auth@v0
+      with:
+        workload_identity_provider: 'projects/28141583151/locations/global/workloadIdentityPools/github/providers/github-actions'
+        service_account: 'github@spec-previews.iam.gserviceaccount.com'
+    - name: Build (head)
+      run: |
+        make ci
+        cp -rv out out-head
+    - name: Build (base)
+      run: |
+        git checkout HEAD^
+        make ci
+        cp -rv out out-base
+    - name: Checkout w3c/htmldiff-ui
+      uses: actions/checkout@v3
+      with:
+        repository: w3c/htmldiff-ui
+        ref: refs/heads/main
+        path: htmldiff-ui
+    - name: Diff
+      shell: bash
+      run: |
+        mkdir -p out-diff
+        for head_file in $(find out-head -name '*.html'); do
+          base_file=out-base/"${head_file#*/}"
+          diff_file=out-diff/"${head_file#*/}"
+          if [[ -e "$base_file" ]]; then
+            perl htmldiff-ui/htmldiff.pl "$base_file" "$head_file" "$diff_file"
+          fi
+        done
+    - name: Compress
+      shell: bash
+      run: |
+        sudo apt-get install -y brotli
+        mkdir -p out-gcs/diff
+        for head_file in $(find out-head -name '*.html'); do
+          brotli "$head_file" -o out-gcs/"${head_file#*/}"
+        done
+        for diff_file in $(find out-diff -name '*.html'); do
+          brotli "$diff_file" -o out-gcs/diff/"${diff_file#*/}"
+        done
+    - name: Upload to Google Cloud Storage
+      uses: google-github-actions/upload-cloud-storage@v0
+      with:
+        path: out-gcs
+        glob: "**/*.html"
+        destination: "${{ env.GCS_BASE }}"
+        parent: false
+        headers: |-
+          Content-Type: text/html; charset=UTF-8
+          Content-Encoding: br
+    - name: Post comment
+      uses: actions/github-script@v6
+      with:
+        script: |
+          const fs = require("fs");
+          const baseUrl = `https://storage.googleapis.com/${process.env.GCS_BASE}`;
+          let body = "<!-- preview-magic-74656 -->Preview:";
+          for (let headFile of await fs.promises.readdir("out-head")) {
+            if (!headFile.endsWith('.html')) continue;
+            body += `\n- [${headFile}](${baseUrl}/${headFile})`;
+            const diffExists = await fs.promises.access(`out-diff/${headFile}`)
+                .then(() => true, () => false);
+            if (diffExists)
+              body += ` ([diff](${baseUrl}/diff/${headFile}))`;
+          }
+          console.log(body);
+          const issue = {...context.repo, issue_number: context.issue.number};
+          const comments = await github.paginate(
+              github.rest.issues.listComments.endpoint.merge({...issue});
+          let comment = comments.find(
+              comment => comment.body.includes("<!-- preview-magic-74656 -->"));
+          if (comment) {
+            await github.rest.issues.updateComment({...issue, comment_id: comment.id, body});
+          } else {
+            await github.rest.issues.createComment({...issue, body})
+          }

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -10,8 +10,6 @@ jobs:
     permissions:
       contents: 'read'
       id-token: 'write'
-      issues: 'write'
-      pull-requests: 'write'
     env:
       GCS_BASE: "spec-previews/${{ github.repository }}/pull/${{ github.event.number }}"
     steps:

--- a/.pr-preview.json
+++ b/.pr-preview.json
@@ -1,7 +1,0 @@
-{
-  "src_file": "index.bs",
-  "type": "bikeshed",
-  "params": {
-    "die-on": "warning"
-  }
-}


### PR DESCRIPTION
pr-preview doesn't support multiple files (and it's regrettably difficult to add), so use GitHub Actions to replicate the feature, similar to how the deployment action works.

The results are stored in a Google Cloud Storage bucket on my personal account to which GitHub authenticates using OpenID Connect, which is quite cool and avoids the need for a secret token. The generated specs are Brotli compressed and quite small in practice.