### PR TITLE
Remove bad link to navigate-to.

### DIFF
--- a/prerendering.bs
+++ b/prerendering.bs
@@ -529,7 +529,7 @@ Every {{Document}} has an <dfn for="Document">activation start time</dfn>, which
       * |browsingContext|'s [=active document=]'s [=Document/prerendering browsing contexts map=][(|request|'s [=request/URL=], |request|'s [=request/referrer policy=])] [=map/exists=] and is not [=prerendering browsing context/empty=]
       * The result of calling [=should navigation request of type be blocked by content security policy?=] given |request| and <var ignore>navigationType</var> is "`Allowed`".
 
-        <p class="note">There is no need for an additional CSP check for the response, see [=navigate-to=].
+        <p class="note">There is no need for an additional CSP check for the response, see <tt>navigate-to</tt> (before it was <a href="https://github.com/w3c/webappsec-csp/pull/564">removed</a>.
 
   1. Otherwise, return false.
 


### PR DESCRIPTION
This fixes the build. If we want to clean this up more in the future, we can do so.