### PR TITLE
Add spec for Speculation-Rules header

### DIFF
--- a/speculation-rules.bs
+++ b/speculation-rules.bs
@@ -249,18 +249,18 @@ Note: This section contains modifications to [[HTML]].
     1. If |item| is not a [=string=], then [=iteration/continue=].
     1. Let |parsedURL| be the result of [=basic URL parser|parsing=] |item| with |baseUrl|.
     1. If |parsedURL| is failure, then [=iteration/continue=].
-    1. Let |pendingResource| be a [=pending external speculation rule resource=] with [=pending external speculation rule resource/URL=] |parsedURL| and [=pending external speculation rule resource/controller=] null
+    1. Let |pendingResource| be a [=pending external speculation rule resource=] with [=pending external speculation rule resource/URL=] |parsedURL| and [=pending external speculation rule resource/controller=] null.
     1. [=list/Append=] |pendingResource| to |document|'s [=document/list of pending external speculation rule resources=].
   1. [=Process pending external speculation rule resources=] given |document|.
 </div>
 
-In [=shared document creation infrastructure=], before the step
+In <a spec="HTML">create and initialize a `Document` object</a>, before the step
 
   > 19. Return <var ignore>document</var>.
 
 add the following step
 
-  > 19. [=process the Speculation-Rules header|Process the Speculation-Rules header=] given <var ignore>document</var> and <var ignore>navigationParams</var>'s [=response=].
+  > 19. [=Process the Speculation-Rules header=] given <var ignore>document</var> and <var ignore>navigationParams</var>'s [=response=].
 
 <h3 id="external-speculation-rule-sets">External speculation rule sets</h3>
 
@@ -286,7 +286,7 @@ add the following step
   1. Let |settingsObject| be |document|'s [=relevant settings object=].
   1. Let |requestURL| be |pendingResource|'s [=pending external speculation rule resource/URL=].
   1. Let |request| be a new [=request=] whose [=request/URL=] is |requestURL|, [=request/client=] is |settingsObject|, and [=request/mode=] is "`cors`".
-  1. Let |controller| be the result of [=fetching=] given |request| with [=fetch/processResponseConsumeBody=] set to the following steps given [=response=] |response| and null, failure, or a [=byte sequence=] |body|:
+  1. Let |controller| be the result of [=fetching=] given |request| with <i>[=fetch/processResponseConsumeBody=]</i> set to the following steps given [=response=] |response| and null, failure, or a [=byte sequence=] |body|:
     1. [=list/Remove=] |pendingResource| from |pendingResources|.
     1. If any of the following conditions are true, abort these steps:
       * |body| is null.

--- a/speculation-rules.bs
+++ b/speculation-rules.bs
@@ -46,7 +46,7 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
     urlPrefix: urls-and-fetching.html
       text: valid non-empty URLs potentially surrounded by spaces; url: valid-non-empty-url-potentially-surrounded-by-spaces
     urlPrefix: document-lifecycle.html
-      text: load an HTML document; url: navigate-html
+      text: shared document creation infrastructure; url: shared-document-creation-infrastructure
 spec: urlpattern; urlPrefix: https://wicg.github.io/urlpattern/
   type: interface; text: URLPattern; url: urlpattern
   type: constructor; for: URLPattern; text: "URLPattern(input, baseURL)"; url: dom-urlpattern-urlpattern
@@ -248,53 +248,69 @@ Note: This section contains modifications to [[HTML]].
   1. [=list/For each=] |item| of |parsedList|:
     1. If |item| is not a [=string=], then [=iteration/continue=].
     1. Let |parsedURL| be the result of [=basic URL parser|parsing=] |item| with |baseUrl|.
-      <p class="issue">TODO: Resolve before merging. Is it necessary to explicitly trim here? Parsing does so internally, but also signals a validation error.</p>
     1. If |parsedURL| is failure, then [=iteration/continue=].
     1. Let |pendingResource| be a [=pending external speculation rule resource=] with [=pending external speculation rule resource/URL=] |parsedURL| and [=pending external speculation rule resource/controller=] null
     1. [=list/Append=] |pendingResource| to |document|'s [=document/list of pending external speculation rule resources=].
-  1. Optionally, [=fetch pending external speculation rule resources=] given |document|.
+  1. [=Process pending external speculation rule resources=] given |document|.
 </div>
 
-In [=load an HTML document=], before the step
+In [=shared document creation infrastructure=], before the step
 
-  > 3. Return |document|.
+  > 19. Return <var ignore>document</var>.
 
-add the step
+add the following step
 
-  > 3. [=process the Speculation-Rules header|Process the Speculation-Rules header=] given |document| and <var ignore>navigationParams</var>'s [=response=]
+  > 19. [=process the Speculation-Rules header|Process the Speculation-Rules header=] given <var ignore>document</var> and <var ignore>navigationParams</var>'s [=response=].
 
 <h3 id="external-speculation-rule-sets">External speculation rule sets</h3>
 
-<div algorithm="fetch pending external speculation rule resources">
+<div algorithm="process pending external speculation rule resources">
 
-  To <dfn>fetch pending external speculation rule resources</dfn> given a [=document=] |document|:
+  To <dfn>process pending external speculation rule resources</dfn> given a [=document=] |document|:
 
   1. Let |pendingResources| be |document|'s [=document/list of pending external speculation rule resources=].
-  1. Let |settingsObject| be |document|'s [=relevant settings object=].
   1. [=list/For each=] |pendingResource| of |pendingResources|:
-    1. Optionally, [=iteration/continue=].
-    1. If |pendingResource|'s [=pending external speculation rule resource/controller=] is not null, [=iteration/continue=].
-    1. Let |request| be a new [=request=] whose [=request/URL=] is |pendingResource|'s [=pending external speculation rule resource/URL=], [=request/client=] is |settingsObject|, and [=request/mode=] is "`cors`".
-    1. Let |controller| be the result of [=fetching=] given |request| with [=fetch/processResponseConsumeBody=] set to [=process an external speculation rule response body=].
-    1. Set |pendingResource|'s [=pending external speculation rule resource/controller=] to |controller|.
+    1. Optionally, [=pending external speculation rule resource/cancel and discard=] |pendingResource| given |document|, then [=iteration/continue=].
+    1. If |pendingResource|'s [=pending external speculation rule resource/controller=] is not null, then [=iteration/continue=].
+    1. Optionally, [=pending external speculation rule resource/fetch=] |pendingResource| given |document|.
+      <p class="note">The user agent may schedule the fetch of external speculation rules at its discretion.</p>
 
 </div>
 
-<div algorithm="process external speculation rule response body">
+<div algorithm="fetch a pending external speculation rule resource">
 
-  To <dfn>process an external speculation rule response body</dfn> given a [=response=] |response| and |body|:
-  1. If any of the following conditions are true:
-    * |body| is null.
-    * |body| is failure.
-    * |response|'s [=response/status=] is not an [=ok status=].
-    * TODO empty body
-    * TODO "`application/speculationrules+json`"
-      <p>then TODO remove pending and return.</p>
-  1. Let |text| be the result of [=UTF-8 decoding=] |body|.
-  1. TODO parse rules |text|
-  1. TODO handle parse error
-  1. TODO add rule set
-  1. TODO remove pending
+  To <dfn for="pending external speculation rule resource">fetch</dfn> a [=pending external speculation rule resource=] |pendingResource| given a [=document=] |document|:
+  1. Let |pendingResources| be |document|'s [=document/list of pending external speculation rule resources=].
+  1. [=Assert=]: |pendingResources| [=list/contains=] |pendingResource|.
+  1. [=Assert=]: |pendingResource|'s [=pending external speculation rule resource/controller=] is null.
+  1. Let |settingsObject| be |document|'s [=relevant settings object=].
+  1. Let |requestURL| be |pendingResource|'s [=pending external speculation rule resource/URL=].
+  1. Let |request| be a new [=request=] whose [=request/URL=] is |requestURL|, [=request/client=] is |settingsObject|, and [=request/mode=] is "`cors`".
+  1. Let |controller| be the result of [=fetching=] given |request| with [=fetch/processResponseConsumeBody=] set to the following steps given [=response=] |response| and null, failure, or a [=byte sequence=] |body|:
+    1. [=list/Remove=] |pendingResource| from |pendingResources|.
+    1. If any of the following conditions are true, abort these steps:
+      * |body| is null.
+      * |body| is failure.
+      * |response|'s [=response/status=] is not an [=ok status=].
+      * The result of [=header list/extracting a MIME type=] from |response|'s [=response/header list=] does not have an [=MIME type/essence=] of "`application/speculationrules+json`".
+    1. Otherwise, let |text| be the result of [=UTF-8 decoding=] |body|.
+    1. Let |ruleSet| be the result of [=parsing speculation rules=] given |text| and |requestURL|.
+    1. If |ruleSet| is null, abort these steps.
+      <p class="note">User agents are encouraged to report failures of the previous steps.</p>
+    1. [=list/Append=] |ruleSet| to |document|'s [=document/list of speculation rule sets=]
+  1. Set |pendingResource|'s [=pending external speculation rule resource/controller=] to |controller|.
+
+</div>
+
+<div algorithm="cancel and discard a pending external speculation rule resource">
+
+  To <dfn for="pending external speculation rule resource">cancel and discard</dfn> a [=pending external speculation rule resource=] |pendingResource| given a [=document=] |document|:
+
+  1. Let |pendingResources| be |document|'s [=document/list of pending external speculation rule resources=].
+  1. [=Assert=]: |pendingResources| [=list/contains=] |pendingResource|.
+  1. Let |controller| be |pendingResource|'s [=pending external speculation rule resource/controller=].
+  1. If |controller| is not null, [=fetch controller/abort=] |controller|.
+  1. [=list/Remove=] |pendingResource| from |pendingResources|.
 </div>
 
 <h3 id="speculation-rules-parsing">Parsing</h3>
@@ -422,13 +438,16 @@ add the step
 
 A [=document=] has a <dfn for=document export>list of speculation rule sets</dfn>, which is an initially empty [=list=].
 
-A [=document=] has a <dfn for=document export>list of pending external speculation rule resources</dfn>, which is an initially empty [=list=].
+A [=document=] has a <dfn for=document export>list of pending external speculation rule resources</dfn>, which is an initially empty [=list=] of [=pending external speculation rule resources=].
 
 <!-- TODO(domfarolino): Get rid of the `data-link-type="interface"` once we fix the dfn in HTML. -->
-Periodically, for any [=document=] |document|, the user agent may [=queue a global task=] on the <a data-link-type="interface">DOM manipulation task source</a> with |document|'s [=relevant global object=] to [=consider speculation=] for |document|. The user agent may also [=queue a global task=] on the [=networking task source=] with |document|'s [=relevant global object=] to [=fetch pending external speculation rule resources=] given |document|.
+Periodically, for any [=document=] |document|, the user agent may [=queue a global task=] on the <a data-link-type="interface">DOM manipulation task source</a> with |document|'s [=relevant global object=] to [=consider speculation=] for |document|. The user agent may also [=queue a global task=] on the [=networking task source=] with |document|'s [=relevant global object=] to [=process pending external speculation rule resources=] given |document|.
 
 <p class="note">
   The user agent will likely do when resources are idle and available, or otherwise the circumstances of its previous decision whether to start a speculation could have changed.
+</p>
+<p class="note">
+  The user agent may still [=consider speculation=] when there are [=document/list of pending external speculation rule resources|rule sets that have not been loaded yet=].
 </p>
 
 A <dfn>prefetch candidate</dfn> is a [=struct=] with the following [=struct/items=]:

--- a/speculation-rules.bs
+++ b/speculation-rules.bs
@@ -43,11 +43,21 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
       text: rules for choosing a browsing context; url: the-rules-for-choosing-a-browsing-context-given-a-browsing-context-name
     urlPrefix: semantics.html
       text: get an element's target; url: get-an-element's-target
+    urlPrefix: urls-and-fetching.html
+      text: valid non-empty URLs potentially surrounded by spaces; url: valid-non-empty-url-potentially-surrounded-by-spaces
+    urlPrefix: document-lifecycle.html
+      text: load an HTML document; url: navigate-html
 spec: urlpattern; urlPrefix: https://wicg.github.io/urlpattern/
   type: interface; text: URLPattern; url: urlpattern
   type: constructor; for: URLPattern; text: "URLPattern(input, baseURL)"; url: dom-urlpattern-urlpattern
   type: dictionary; text: URLPatternInit
   type: dfn; text: match; url: match
+spec: RFC8941; urlPrefix: https://httpwg.org/specs/rfc8941.html
+  type: dfn
+    text: structured header; url: top
+    for: structured header
+      text: list; url: list
+      text: string; url: string
 spec: nav-speculation; urlPrefix: prefetch.html
   type: dfn
     text: prefetch; url: prefetch
@@ -111,9 +121,15 @@ A <dfn>speculation rule</dfn> is a [=struct=] with the following [=struct/items=
 
 The only valid string for [=speculation rule/requirements=] to contain is "`anonymous-client-ip-when-cross-origin`".
 
+The <dfn http-header><code>Speculation-Rules</code></dfn> HTTP response header is a [=structured header=] whose value must be a [=structured header/list=] whose members must be [=structured header/strings=] which are [=valid non-empty URLs potentially surrounded by spaces=].
+
 A <dfn>speculation rule set</dfn> is a [=struct=] with the following [=struct/items=]:
 * <dfn for="speculation rule set">prefetch rules</dfn>, a [=list=] of [=speculation rules=]
 * <dfn for="speculation rule set">prerender rules</dfn>, a [=list=] of [=speculation rules=]
+
+A <dfn>pending external speculation rule resource</dfn> is a [=struct=] with the following [=struct/items=]:
+* <dfn for="pending external speculation rule resource">URL</dfn>, a [=URL=]
+* <dfn for="pending external speculation rule resource">controller</dfn>, a [=fetch controller=] or null
 
 A <dfn>document rule predicate</dfn> is one of the following:
 * [=document rule conjunction=]
@@ -217,6 +233,69 @@ Inside the [=prepare the script element=] algorithm we make the following change
     </dd>
   </dl>
 
+<h3 id="speculation-rules-header">The [:Speculation-Rules:] header</h3>
+Note: This section contains modifications to [[HTML]].
+
+<div algorithm="process the Speculation-Rules header">
+
+  To <dfn>process the Speculation-Rules header</dfn> given a [=document=] |document| and a [=response=] |response|:
+
+  1. Optionally, return.
+    <p class="note">The user agent could ignore this header, for example, if it does not intend to [=consider speculation=] for |document|.</p>
+  1. Let |parsedList| be the result of [=header list/getting a structured field value=] given [:Speculation-Rules:] and "`list`" from |response|'s [=response/header list=].
+  1. If |parsedList| is null, then return.
+  1. Let |baseUrl| be |document|'s [=document base URL=].
+  1. [=list/For each=] |item| of |parsedList|:
+    1. If |item| is not a [=string=], then [=iteration/continue=].
+    1. Let |parsedURL| be the result of [=basic URL parser|parsing=] |item| with |baseUrl|.
+      <p class="issue">TODO: Resolve before merging. Is it necessary to explicitly trim here? Parsing does so internally, but also signals a validation error.</p>
+    1. If |parsedURL| is failure, then [=iteration/continue=].
+    1. Let |pendingResource| be a [=pending external speculation rule resource=] with [=pending external speculation rule resource/URL=] |parsedURL| and [=pending external speculation rule resource/controller=] null
+    1. [=list/Append=] |pendingResource| to |document|'s [=document/list of pending external speculation rule resources=].
+  1. Optionally, [=fetch pending external speculation rule resources=] given |document|.
+</div>
+
+In [=load an HTML document=], before the step
+
+  > 3. Return |document|.
+
+add the step
+
+  > 3. [=process the Speculation-Rules header|Process the Speculation-Rules header=] given |document| and <var ignore>navigationParams</var>'s [=response=]
+
+<h3 id="external-speculation-rule-sets">External speculation rule sets</h3>
+
+<div algorithm="fetch pending external speculation rule resources">
+
+  To <dfn>fetch pending external speculation rule resources</dfn> given a [=document=] |document|:
+
+  1. Let |pendingResources| be |document|'s [=document/list of pending external speculation rule resources=].
+  1. Let |settingsObject| be |document|'s [=relevant settings object=].
+  1. [=list/For each=] |pendingResource| of |pendingResources|:
+    1. Optionally, [=iteration/continue=].
+    1. If |pendingResource|'s [=pending external speculation rule resource/controller=] is not null, [=iteration/continue=].
+    1. Let |request| be a new [=request=] whose [=request/URL=] is |pendingResource|'s [=pending external speculation rule resource/URL=], [=request/client=] is |settingsObject|, and [=request/mode=] is "`cors`".
+    1. Let |controller| be the result of [=fetching=] given |request| with [=fetch/processResponseConsumeBody=] set to [=process an external speculation rule response body=].
+    1. Set |pendingResource|'s [=pending external speculation rule resource/controller=] to |controller|.
+
+</div>
+
+<div algorithm="process external speculation rule response body">
+
+  To <dfn>process an external speculation rule response body</dfn> given a [=response=] |response| and |body|:
+  1. If any of the following conditions are true:
+    * |body| is null.
+    * |body| is failure.
+    * |response|'s [=response/status=] is not an [=ok status=].
+    * TODO empty body
+    * TODO "`application/speculationrules+json`"
+      <p>then TODO remove pending and return.</p>
+  1. Let |text| be the result of [=UTF-8 decoding=] |body|.
+  1. TODO parse rules |text|
+  1. TODO handle parse error
+  1. TODO add rule set
+  1. TODO remove pending
+</div>
 
 <h3 id="speculation-rules-parsing">Parsing</h3>
 
@@ -343,8 +422,10 @@ Inside the [=prepare the script element=] algorithm we make the following change
 
 A [=document=] has a <dfn for=document export>list of speculation rule sets</dfn>, which is an initially empty [=list=].
 
+A [=document=] has a <dfn for=document export>list of pending external speculation rule resources</dfn>, which is an initially empty [=list=].
+
 <!-- TODO(domfarolino): Get rid of the `data-link-type="interface"` once we fix the dfn in HTML. -->
-Periodically, for any [=document=] |document|, the user agent may [=queue a global task=] on the <a data-link-type="interface">DOM manipulation task source</a> with |document|'s [=relevant global object=] to [=consider speculation=] for |document|.
+Periodically, for any [=document=] |document|, the user agent may [=queue a global task=] on the <a data-link-type="interface">DOM manipulation task source</a> with |document|'s [=relevant global object=] to [=consider speculation=] for |document|. The user agent may also [=queue a global task=] on the [=networking task source=] with |document|'s [=relevant global object=] to [=fetch pending external speculation rule resources=] given |document|.
 
 <p class="note">
   The user agent will likely do when resources are idle and available, or otherwise the circumstances of its previous decision whether to start a speculation could have changed.

--- a/speculation-rules.bs
+++ b/speculation-rules.bs
@@ -43,10 +43,6 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
       text: rules for choosing a browsing context; url: the-rules-for-choosing-a-browsing-context-given-a-browsing-context-name
     urlPrefix: semantics.html
       text: get an element's target; url: get-an-element's-target
-    urlPrefix: urls-and-fetching.html
-      text: valid non-empty URLs potentially surrounded by spaces; url: valid-non-empty-url-potentially-surrounded-by-spaces
-    urlPrefix: document-lifecycle.html
-      text: shared document creation infrastructure; url: shared-document-creation-infrastructure
 spec: urlpattern; urlPrefix: https://wicg.github.io/urlpattern/
   type: interface; text: URLPattern; url: urlpattern
   type: constructor; for: URLPattern; text: "URLPattern(input, baseURL)"; url: dom-urlpattern-urlpattern
@@ -120,8 +116,6 @@ A <dfn>speculation rule</dfn> is a [=struct=] with the following [=struct/items=
 * <dfn for="speculation rule">target browsing context name hint</dfn>, a [=string=] or null
 
 The only valid string for [=speculation rule/requirements=] to contain is "`anonymous-client-ip-when-cross-origin`".
-
-The <dfn http-header><code>Speculation-Rules</code></dfn> HTTP response header is a [=structured header=] whose value must be a [=structured header/list=] whose members must be [=structured header/strings=] which are [=valid non-empty URLs potentially surrounded by spaces=].
 
 A <dfn>speculation rule set</dfn> is a [=struct=] with the following [=struct/items=]:
 * <dfn for="speculation rule set">prefetch rules</dfn>, a [=list=] of [=speculation rules=]
@@ -236,7 +230,9 @@ Inside the [=prepare the script element=] algorithm we make the following change
 <h3 id="speculation-rules-header">The [:Speculation-Rules:] header</h3>
 Note: This section contains modifications to [[HTML]].
 
-<div algorithm="process the Speculation-Rules header">
+The <dfn http-header><code>Speculation-Rules</code></dfn> HTTP response header is a [=structured header=] whose value must be a [=structured header/list=] whose members must be [=structured header/strings=] which are [=valid URL strings=].
+
+<div algorithm>
 
   To <dfn>process the Speculation-Rules header</dfn> given a [=document=] |document| and a [=response=] |response|:
 
@@ -264,7 +260,7 @@ add the following step
 
 <h3 id="external-speculation-rule-sets">External speculation rule sets</h3>
 
-<div algorithm="process pending external speculation rule resources">
+<div algorithm=>
 
   To <dfn>process pending external speculation rule resources</dfn> given a [=document=] |document|:
 
@@ -273,11 +269,11 @@ add the following step
     1. Optionally, [=pending external speculation rule resource/cancel and discard=] |pendingResource| given |document|, then [=iteration/continue=].
     1. If |pendingResource|'s [=pending external speculation rule resource/controller=] is not null, then [=iteration/continue=].
     1. Optionally, [=pending external speculation rule resource/fetch=] |pendingResource| given |document|.
-      <p class="note">The user agent may schedule the fetch of external speculation rules at its discretion.</p>
+      <p class="note">The user agent may schedule the fetch of external speculation rules at its discretion. That is, if it skips the fetch during this call of [=process pending external speculation rule resources=], it might do the fetch during a later call.</p>
 
 </div>
 
-<div algorithm="fetch a pending external speculation rule resource">
+<div algorithm>
 
   To <dfn for="pending external speculation rule resource">fetch</dfn> a [=pending external speculation rule resource=] |pendingResource| given a [=document=] |document|:
   1. Let |pendingResources| be |document|'s [=document/list of pending external speculation rule resources=].
@@ -294,15 +290,15 @@ add the following step
       * |response|'s [=response/status=] is not an [=ok status=].
       * The result of [=header list/extracting a MIME type=] from |response|'s [=response/header list=] does not have an [=MIME type/essence=] of "`application/speculationrules+json`".
     1. Otherwise, let |text| be the result of [=UTF-8 decoding=] |body|.
-    1. Let |ruleSet| be the result of [=parsing speculation rules=] given |text| and |requestURL|.
+    1. Let |ruleSet| be the result of [=parsing speculation rules=] given |text| and |response|'s [=response/URL=].
     1. If |ruleSet| is null, abort these steps.
       <p class="note">User agents are encouraged to report failures of the previous steps.</p>
-    1. [=list/Append=] |ruleSet| to |document|'s [=document/list of speculation rule sets=]
+    1. [=list/Append=] |ruleSet| to |document|'s [=document/list of speculation rule sets=].
   1. Set |pendingResource|'s [=pending external speculation rule resource/controller=] to |controller|.
 
 </div>
 
-<div algorithm="cancel and discard a pending external speculation rule resource">
+<div algorithm>
 
   To <dfn for="pending external speculation rule resource">cancel and discard</dfn> a [=pending external speculation rule resource=] |pendingResource| given a [=document=] |document|:
 
@@ -441,7 +437,7 @@ A [=document=] has a <dfn for=document export>list of speculation rule sets</dfn
 A [=document=] has a <dfn for=document export>list of pending external speculation rule resources</dfn>, which is an initially empty [=list=] of [=pending external speculation rule resources=].
 
 <!-- TODO(domfarolino): Get rid of the `data-link-type="interface"` once we fix the dfn in HTML. -->
-Periodically, for any [=document=] |document|, the user agent may [=queue a global task=] on the <a data-link-type="interface">DOM manipulation task source</a> with |document|'s [=relevant global object=] to [=consider speculation=] for |document|. The user agent may also [=queue a global task=] on the [=networking task source=] with |document|'s [=relevant global object=] to [=process pending external speculation rule resources=] given |document|.
+Periodically, for any [=document=] |document|, the user agent may [=queue a global task=] on the <a data-link-type="interface">DOM manipulation task source</a> with |document|'s [=relevant global object=] to [=consider speculation=] for |document|.
 
 <p class="note">
   The user agent will likely do when resources are idle and available, or otherwise the circumstances of its previous decision whether to start a speculation could have changed.
@@ -449,6 +445,8 @@ Periodically, for any [=document=] |document|, the user agent may [=queue a glob
 <p class="note">
   The user agent may still [=consider speculation=] when there are [=document/list of pending external speculation rule resources|rule sets that have not been loaded yet=].
 </p>
+
+The user agent may also [=queue a global task=] on the [=networking task source=] with |document|'s [=relevant global object=] to [=process pending external speculation rule resources=] given |document|.
 
 A <dfn>prefetch candidate</dfn> is a [=struct=] with the following [=struct/items=]:
 * <dfn for="prefetch candidate">URL</dfn>, a [=URL=]


### PR DESCRIPTION
We add specification text for the processing of the Speculation-Rules HTTP response header and the handling of external speculation rule resources.