### PR TITLE
Remove extra equals sign from speculation rules spec

### DIFF
--- a/speculation-rules.bs
+++ b/speculation-rules.bs
@@ -260,7 +260,7 @@ add the following step
 
 <h3 id="external-speculation-rule-sets">External speculation rule sets</h3>
 
-<div algorithm=>
+<div algorithm>
 
   To <dfn>process pending external speculation rule resources</dfn> given a [=document=] |document|:
 


### PR DESCRIPTION
I left this in accidentally when switching to default algorithm names in #202.