### PR TITLE
Update speculation rules spec for navigables

### DIFF
--- a/speculation-rules.bs
+++ b/speculation-rules.bs
@@ -38,9 +38,9 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
       text: await a stable state; url: await-a-stable-state
       text: script; url: concept-script
       text: synchronous section; url: synchronous-section
-    urlPrefix: browsers.html
-      text: valid browsing context name or keyword; url: valid-browsing-context-name-or-keyword
-      text: rules for choosing a browsing context; url: the-rules-for-choosing-a-browsing-context-given-a-browsing-context-name
+    urlPrefix: document-sequences.html
+      text: valid navigable target name or keyword; url: valid-navigable-target-name-or-keyword
+      text: rules for choosing a navigable; url: the-rules-for-choosing-a-navigable
     urlPrefix: semantics.html
       text: get an element's target; url: get-an-element's-target
 spec: urlpattern; urlPrefix: https://wicg.github.io/urlpattern/
@@ -71,7 +71,8 @@ spec: nav-speculation; urlPrefix: prefetch.html
 spec: nav-speculation; urlPrefix: prerendering.html
   type: dfn
     text: start referrer-initiated prerendering; url: start-referrer-initiated-prerendering
-    text: activate; for: prerendering browsing context; url: prerendering-browsing-context-activate
+    text: prerendering traversable; url: prerendering-traversable
+    text: activate; for: prerendering traversable; url: prerendering-traversable-activate
 </pre>
 <style>
 /* domintro from https://resources.whatwg.org/standard.css */
@@ -113,7 +114,7 @@ A <dfn>speculation rule</dfn> is a [=struct=] with the following [=struct/items=
 * <dfn for="speculation rule">URLs</dfn>, an [=ordered set=] of [=URLs=]
 * <dfn for="speculation rule">predicate</dfn>, a [=document rule predicate=] or null
 * <dfn for="speculation rule">requirements</dfn>, an [=ordered set=] of [=strings=]
-* <dfn for="speculation rule">target browsing context name hint</dfn>, a [=string=] or null
+* <dfn for="speculation rule">target navigable name hint</dfn>, a [=string=] or null
 
 The only valid string for [=speculation rule/requirements=] to contain is "`anonymous-client-ip-when-cross-origin`".
 
@@ -325,7 +326,7 @@ add the following step
     1. If |prefetchRule| is not a [=map=], then [=iteration/continue=].
     1. Let |rule| be the result of [=parsing a speculation rule=] given |prefetchRule| and |baseURL|.
     1. If |rule| is null, then [=iteration/continue=].
-    1. If |rule|'s [=speculation rule/target browsing context name hint=] is not null, then [=iteration/continue=].
+    1. If |rule|'s [=speculation rule/target navigable name hint=] is not null, then [=iteration/continue=].
     1. [=list/Append=] |rule| to |result|'s [=speculation rule set/prefetch rules=].
   1. If |parsed|["`prerender`"] [=map/exists=] and is a [=list=], then [=list/for each=] |prerenderRule| of |parsed|["`prerender`"]:
     1. If |prerenderRule| is not a [=map=], then [=iteration/continue=].
@@ -365,9 +366,9 @@ add the following step
     1. [=set/Append=] |requirement| to |requirements|.
   1. Let |targetHint| be null.
   1. If |input|["`target_hint`"] [=map/exists=]:
-    1. If |input|["`target_hint`"] is not a [=valid browsing context name or keyword=], then return null.
+    1. If |input|["`target_hint`"] is not a [=valid navigable target name or keyword=], then return null.
     1. Set |targetHint| to |input|["`target_hint`"].
-  1. Return a [=speculation rule=] with [=speculation rule/URLs=] |urls|, [=speculation rule/predicate=] |predicate|, [=speculation rule/requirements=] |requirements|, and [=speculation rule/target browsing context name hint=] |targetHint|.
+  1. Return a [=speculation rule=] with [=speculation rule/URLs=] |urls|, [=speculation rule/predicate=] |predicate|, [=speculation rule/requirements=] |requirements|, and [=speculation rule/target navigable name hint=] |targetHint|.
 </div>
 
 <div algorithm="parse a document rule predicate">
@@ -454,7 +455,7 @@ A <dfn>prefetch candidate</dfn> is a [=struct=] with the following [=struct/item
 
 A <dfn>prerender candidate</dfn> is a [=struct=] with the following [=struct/items=]:
 * <dfn for="prerender candidate">URL</dfn>, a [=URL=]
-* <dfn for="prerender candidate">target browsing context name hint</dfn>, a [=valid browsing context name or keyword=] or null
+* <dfn for="prerender candidate">target navigable name hint</dfn>, a [=valid navigable target name or keyword=] or null
 
 <div algorithm>
   A [=prefetch candidate=] |prefetchCandidate| <dfn for="prefetch candidate">continues</dfn> a [=prefetch record=] |prefetchRecord| if the following are all true:
@@ -498,15 +499,15 @@ A <dfn>prerender candidate</dfn> is a [=struct=] with the following [=struct/ite
           1. &#x231B; [=list/Append=] a [=prefetch candidate=] with [=prefetch candidate/URL=] |href|, and [=prefetch candidate/anonymization policy=] |anonymizationPolicy| to |prefetchCandidates|.
     1. &#x231B; [=list/For each=] |rule| of |ruleSet|'s [=speculation rule set/prerender rules=]:
       1. &#x231B; [=list/For each=] |url| of |rule|'s [=speculation rule/URLs=]:
-        1. &#x231B; Let |prerenderCandidate| be a new [=prerender candidate=] whose [=prerender candidate/URL=] is |url| and [=prerender candidate/target browsing context name hint=] is |rule|'s [=speculation rule/target browsing context name hint=].
+        1. &#x231B; Let |prerenderCandidate| be a new [=prerender candidate=] whose [=prerender candidate/URL=] is |url| and [=prerender candidate/target navigable name hint=] is |rule|'s [=speculation rule/target navigable name hint=].
         1. &#x231B; [=list/Append=] |prerenderCandidate| to |prerenderCandidates|.
       1. &#x231B; If |rule|'s [=speculation rule/predicate=] is not null, then:
         1. &#x231B; Let |links| be the result of [=finding matching links=] given |document| and |rule|'s [=speculation rule/predicate=].
         1. &#x231B; [=list/For each=] |link| of |links|:
           1. &#x231B; Let |href| be the result of running |link|'s {{HTMLHyperlinkElementUtils/href}} getter steps.
-          1. &#x231B; Let |target| be |rule|'s [=speculation rule/target browsing context name hint=].
+          1. &#x231B; Let |target| be |rule|'s [=speculation rule/target navigable name hint=].
           1. &#x231B; If |target| is null, set it to the result of [=getting an element's target=] given |link|.
-          1. &#x231B; Let |prerenderCandidate| be a new [=prerender candidate=] whose [=prerender candidate/URL=] is |href|, and [=prerender candidate/target browsing context name hint=] is |target|.
+          1. &#x231B; Let |prerenderCandidate| be a new [=prerender candidate=] whose [=prerender candidate/URL=] is |href|, and [=prerender candidate/target navigable name hint=] is |target|.
           1. &#x231B; [=list/Append=] |prerenderCandidate| to |prerenderCandidates|.
   1. &#x231B; [=list/For each=] |prefetchRecord| of |document|'s [=Document/prefetch records=]:
     1. &#x231B; If |prefetchRecord|'s [=prefetch record/label=] is not "`speculation-rules`", then [=iteration/continue=].
@@ -517,12 +518,12 @@ A <dfn>prerender candidate</dfn> is a [=struct=] with the following [=struct/ite
     1. The user agent may run the following steps:
       1. Let |prefetchRecord| be a new [=prefetch record=] whose [=prefetch record/URL=] is |prefetchCandidate|'s [=prefetch candidate/URL=], [=prefetch record/anonymization policy=] is |prefetchCandidate|'s [=prefetch candidate/anonymization policy=], and [=prefetch record/label=] is "`speculation-rules`".
       1. [=Prefetch=] given |document| and |prefetchRecord|.
-  1. [=list/For each=] |prerenderCandidate| of |prefetchCandidates|:
-      1. The user agent may [=create a prerendering browsing context=] given |prerenderCandidate|'s [=prerender candidate/URL=] and |document|.
+  1. [=list/For each=] |prerenderCandidate| of |prerenderCandidates|:
+      1. The user agent may [=start referrer-initiated prerendering=] given |prerenderCandidate|'s [=prerender candidate/URL=] and |document|.
 
-         The user agent can use |prerenderCandidate|'s [=prerender candidate/target browsing context name hint=] as a hint to their implementation of the [=create a prerendering browsing context=] algorithm. This hint indicates that the web developer expects the eventual [=prerendering browsing context/activate|activation=] of the created browsing context to be in place of a particular predecessor browsing context: the one that would be chosen by the invoking the [=rules for choosing a browsing context=] given |prerenderCandidate|'s [=prerender candidate/target browsing context name hint=] and |document|'s [=Document/browsing context=].
+         The user agent can use |prerenderCandidate|'s [=prerender candidate/target navigable name hint=] as a hint to their implementation of the [=start referrer-initiated prerendering=] algorithm. This hint indicates that the web developer expects the eventual [=prerendering traversable/activate|activation=] of the created [=prerendering traversable=] to be in place of a particular predecessor traversable: the one that would be chosen by the invoking the [=rules for choosing a navigable=] given |prerenderCandidate|'s [=prerender candidate/target navigable name hint=] and |document|'s [=node navigable=].
 
-         <p class="note">This is just a hint. The [=speculation rule/target browsing context name hint=] actually has no normative implications, after being parsed. It is still perfectly fine to [=prerendering browsing context/activate=] in place of a different predecessor browsing context that was not hinted at.
+         <p class="note">This is just a hint. The [=speculation rule/target navigable name hint=] actually has no normative implications, after being parsed. It is still perfectly fine to [=prerendering traversable/activate=] in place of a different predecessor traversable that was not hinted at.
 </div>
 
 <p class="issue">


### PR DESCRIPTION
The recent update to prerendering.bs for the navigable changes to the HTML spec requires additional changes in speculation-rules.bs for it to build and for the links to work.

Some of the links to the html spec still work due to redirects. We now link to the new concepts directly. We also rename "target browsing context name hint" to "target navigable name hint" accordingly.

We also fix an issue where the prerender case of consider speculation was iterating over prefetch candidates.