### PR TITLE
script-src-elem also accepts 'inline-speculation-rules'

### DIFF
--- a/triggers.md
+++ b/triggers.md
@@ -343,10 +343,9 @@ Another envisioned speculative action is `"prefetch_with_subresources"`, which p
 
 ### Content-Security-Policy
 
-Speculation rules can be embedded inline within a `script` tag with `type="speculationrules"`, and restricted by the `script-src` CSP directive.
+Speculation rules can be embedded inline within a `script` tag with `type="speculationrules"`, and restricted by the `script-src` and `script-src-elem` CSP directive.
 To allow inline speculation rules, use either the `'inline-speculation-rules'` or `'unsafe-inline'` keyword.
-Using `script-src 'inline-speculation-rules'` helps developers to permit inline speculation rules but still disallow unsafe inline JavaScript.
-Also `script-src-elem` can accept `'inline-speculation-rules'` to permit inline speculation rules as well.
+Using `script-src 'inline-speculation-rules'` or `script-src-elem 'inline-speculation-rules'` helps developers to permit inline speculation rules but still disallow unsafe inline JavaScript.
 The `prefetch-src` directive can be used to restrict which URLs can be prefetched or prerendered.
 
 ## Proposed processing model

--- a/triggers.md
+++ b/triggers.md
@@ -346,6 +346,7 @@ Another envisioned speculative action is `"prefetch_with_subresources"`, which p
 Speculation rules can be embedded inline within a `script` tag with `type="speculationrules"`, and restricted by the `script-src` CSP directive.
 To allow inline speculation rules, use either the `'inline-speculation-rules'` or `'unsafe-inline'` keyword.
 Using `script-src 'inline-speculation-rules'` helps developers to permit inline speculation rules but still disallow unsafe inline JavaScript.
+Also `script-src-elem` can accept `'inline-speculation-rules'` to permit inline speculation rules as well.
 The `prefetch-src` directive can be used to restrict which URLs can be prefetched or prerendered.
 
 ## Proposed processing model


### PR DESCRIPTION
This CL updates triggers.md explainer to clarify that script-src-elem also can accept 'inline-speculation-rules' to permit inline speculation rules.