### PR TITLE
Pass the specified referrer policy to the prefetch algorithm

### DIFF
--- a/prefetch.bs
+++ b/prefetch.bs
@@ -178,6 +178,7 @@ Each {{Document}} has <dfn export for="Document">prefetch records</dfn>, which i
 A <dfn export>prefetch record</dfn> is a [=struct=] with the following [=struct/items=]:
 * <dfn export for="prefetch record">URL</dfn>, a [=URL=]
 * <dfn export for="prefetch record">anonymization policy</dfn>, a [=prefetch IP anonymization policy=]
+* <dfn export for="prefetch record">referrer policy</dfn>, a [=referrer policy=]
 * <dfn export for="prefetch record">label</dfn>, a [=string=]
 
   <div class="note">This is intended for use by a specification or [=implementation-defined=] feature to identify which prefetches it created. It might also associate other data with this struct.</div>
@@ -591,9 +592,10 @@ The <dfn>list of sufficiently strict speculative navigation referrer policies</d
     1. [=Assert=]: |prefetchRecord|'s [=prefetch record/URL=]'s [=url/scheme=] is an [=HTTP(S) scheme=].
     1. [=list/Append=] |prefetchRecord| to |document|'s [=Document/prefetch records=]
     1. Set |prefetchRecord|'s [=prefetch record/sandboxing flag set=] to the result of [=determining the creation sandboxing flags=] for |document|'s [=Document/browsing context=] given |document|'s [=node navigable=]'s [=navigable/container=].
+    1. Let |referrerPolicy| be |prefetchRecord|'s [=prefetch record/referrer policy=] if |prefetchRecord|'s [=prefetch record/referrer policy=] is not the empty string, and |document|'s [=Document/policy container=]'s [=policy container/referrer policy=] otherwise.
     1. Let |documentState| be a new [=document state=] with
         :  [=document state/request referrer policy=]
-        :: |document|'s [=Document/policy container=]'s [=policy container/referrer policy=]
+        :: |referrerPolicy|
         :  [=document state/initiator origin=]
         :: |document|'s [=Document/origin=]
     1. Let |entry| be a new [=session history entry=] with

--- a/speculation-rules.bs
+++ b/speculation-rules.bs
@@ -70,6 +70,7 @@ spec: nav-speculation; urlPrefix: prefetch.html
     for: prefetch record
       text: URL; url: prefetch-record-url
       text: anonymization policy; url: prefetch-record-anonymization-policy
+      text: referrer policy; url: prefetch-record-referrer-policy
       text: label; url: prefetch-record-label
       text: state; url: prefetch-record-state
       text: cancel and discard; url: prefetch-record-cancel-and-discard
@@ -555,8 +556,7 @@ A <dfn>prerender candidate</dfn> is a [=struct=] with the following [=struct/ite
   1. End the [=synchronous section=], continuing the remaining steps [=in parallel=].
   1. [=list/For each=] |prefetchCandidate| of |prefetchCandidates|:
     1. The user agent may run the following steps:
-      1. Let |prefetchRecord| be a new [=prefetch record=] whose [=prefetch record/URL=] is |prefetchCandidate|'s [=prefetch candidate/URL=], [=prefetch record/anonymization policy=] is |prefetchCandidate|'s [=prefetch candidate/anonymization policy=], and [=prefetch record/label=] is "`speculation-rules`".
-        <p class="issue">Pass along |prefetchCandidate|'s [=prefetch candidate/referrer policy=].<p>
+      1. Let |prefetchRecord| be a new [=prefetch record=] whose [=prefetch record/URL=] is |prefetchCandidate|'s [=prefetch candidate/URL=], [=prefetch record/anonymization policy=] is |prefetchCandidate|'s [=prefetch candidate/anonymization policy=], [=prefetch record/referrer policy=] is |prefetchCandidate|'s [=prefetch candidate/referrer policy=], and [=prefetch record/label=] is "`speculation-rules`".
       1. [=Prefetch=] given |document| and |prefetchRecord|.
   1. [=list/For each=] |prerenderCandidate| of |prerenderCandidates|:
       1. The user agent may [=start referrer-initiated prerendering=] given |prerenderCandidate|'s [=prerender candidate/URL=], |document|, and |prerenderCandidate|'s [=prerender candidate/referrer policy=].


### PR DESCRIPTION
This finishes the plumbing needed by the referrer policy key.