### PR TITLE
Fix various linking errors

### DIFF
--- a/prefetch.bs
+++ b/prefetch.bs
@@ -23,8 +23,8 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
       text: cross-origin opener policy; url: cross-origin-opener-policy
       for: cross-origin opener policy
         text: value; url: coop-struct-value
-        text: reporting endpoint; url: coop-report-endpoint
-        text: report-only reporting endpoint; url: coop-report-only-endpoint
+        text: reporting endpoint; url: coop-struct-report-endpoint
+        text: report-only reporting endpoint; url: coop-struct-report-only-endpoint
       for: cross-origin opener policy enforcement result
         text: needs a browsing context group switch; url: coop-enforcement-bcg-switch
         text: would need a browsing context group switch due to report-only; url: coop-enforcement-bcg-switch-report-only
@@ -102,9 +102,7 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
       text: StructuredSerializeForStorage; url: structuredserializeforstorage
 spec: fetch; urlPrefix: https://fetch.spec.whatwg.org/
   type: dfn
-    text: process response; url: process-response
     text: network partition key; url: network-partition-key
-    text: controller; for: fetch params; url: fetch-params-controller
 spec: RFC8941; urlPrefix: https://www.rfc-editor.org/rfc/rfc8941.html
   type: dfn
     text: Item; url: name-items
@@ -330,7 +328,7 @@ A <dfn export>cross-origin prefetch IP anonymization policy</dfn> has an <dfn ex
 
     To <dfn export>create a reserved client</dfn> given a [=navigable=] |navigable|, a [=URL=] |url| and an [=opaque origin=] or null |isolationOrigin|:
     1. Let |topLevelCreationURL| be |url|.
-    1. Let |topLevelOrigin| be null. 
+    1. Let |topLevelOrigin| be null.
     1. If |isolationOrigin| is not null, then: <!-- these are new steps to isolate uncredentialed prefetch -->
         1. Set |topLevelCreationURL| to `about:blank`.
         1. Set |topLevelOrigin| to |isolationOrigin|.
@@ -407,7 +405,7 @@ A <dfn export>cross-origin prefetch IP anonymization policy</dfn> has an <dfn ex
     1. Otherwise, if both of the following are true:
         * <var ignore>entry</var>'s [=session history entry/URL=]'s [=url/scheme=] is a [=fetch scheme=]; and
         * <var ignore>documentResource</var> is null, or <var ignore>allowPOST</var> is true and <var ignore>documentResource</var>'s [=POST resource/request body=] is not failure
-        
+
         then:
 
             1. Let |request| be the result of [=creating a navigation request=] given <var ignore>entry</var>, <var ignore>sourceSnapshotParams</var>'s [=source snapshot params/fetch client=], <var ignore>navigable</var>'s [=navigable/container=], and <var ignore>sourceSnapshotParams</var>'s [=source snapshot params/has transient activation=].
@@ -449,7 +447,7 @@ A <dfn export>cross-origin prefetch IP anonymization policy</dfn> has an <dfn ex
     1. Let |commitEarlyHints| be null.
     1. Let |isolationOrigin| be null.
     1. If |prefetchRecord| was given and its [=prefetch record/partition state=] is a [=cross-partition prefetch state=]:
-        1. Let |isolationSite| be |prefetchRecord|'s [=prefetch record/partition state=]'s [=cross-partition prefetch state/isolated partition key=][0]. 
+        1. Let |isolationSite| be |prefetchRecord|'s [=prefetch record/partition state=]'s [=cross-partition prefetch state/isolated partition key=][0].
         1. [=Assert=]: |isolationSite| is an [=opaque origin=].
         1. Set |isolationOrigin| to |isolationSite|.
     1. While true:
@@ -491,7 +489,7 @@ A <dfn export>cross-origin prefetch IP anonymization policy</dfn> has an <dfn ex
 
             Let |processEarlyHintsResponse| be the following algorithm given a [=response=] |earlyResponse|:
                 1. If |prefetchRecord| was given and |commitEarlyHints| is null, then set |commitEarlyHints| to the result of [=processing early hint headers=] given |earlyResponse| and |request|'s [=request/reserved client=]. <!-- this has an additional condition to suppress extra fetches due to early hints while prefetching -->
-            
+
             Let |processResponse| be the following algorithm given a [=response=] |fetchedResponse|:
                 1. Set |response| to |fetchedResponse|.
         1. Otherwise, [=fetch controller/process the next manual redirect=] for |fetchController|.

--- a/prerendering.bs
+++ b/prerendering.bs
@@ -15,10 +15,6 @@ Complain About: accidental-2119 yes, missing-example-ids yes
 Indent: 2
 Boilerplate: omit conformance
 </pre>
-<pre class="link-defaults">
-spec:html; type:element; text:link
-spec:html; type:element; text:script
-</pre>
 <pre class="anchors">
 spec: ecma262; urlPrefix: https://tc39.es/ecma262/
   type: dfn
@@ -48,7 +44,6 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
     for: document state
       text: initiator origin; url: browsing-the-web.html#document-state-initiator-origin
     for: navigable
-      text: active window; url: document-sequences.html#nav-window
       text: ongoing navigation; url: browsing-the-web.html#ongoing-navigation
       text: parent; url: document-sequences.html#nav-parent
     for: navigate
@@ -65,147 +60,15 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
       text: session history entries; url: document-sequences.html#tn-session-history-entries
     for: Window
       text: navigable; url: nav-history-apis.html#window-navigable
-spec: webdriver-idi; urlPrefix: https://w3c.github.io/webdriver-bidi/
-  type: dfn
-    text: WebDriver BiDi navigation started; url: webdriver-bidi-navigation-started
-spec: geolocation; urlPrefix: https://w3c.github.io/geolocation-api/
-  type: method; for: Geolocation
-    text: getCurrentPosition(successCallback, errorCallback, options); url: getcurrentposition-method
-    text: watchPosition(successCallback, errorCallback, options); url: watchposition-method
-    text: clearWatch(watchId); url: clearwatch-method
-  type: dfn
-    text: watch process; url: dfn-watch-process
-spec: serial; urlPrefix: https://wicg.github.io/serial/
-  type: method; for: Serial
-    text: getPorts(); url: dom-serial-getports
-    text: requestPort(options); url: dom-serial-requestPort
-spec: presentation-api; urlPrefix: https://w3c.github.io/presentation-api/
-  type: method; for: PresentationRequest
-    text: start(); url: dom-presentationrequest-start
-spec: webmidi; urlPrefix: https://webaudio.github.io/web-midi-api/
-  type: method; for: Navigator
-    text: requestMIDIAccess(); url: dom-navigator-requestmidiaccess
-spec: file-system-access; urlPrefix: https://wicg.github.io/file-system-access/
-  type: method; for: Window
-    text: showOpenFilePicker(); url: dom-window-showopenfilepicker
-    text: showSaveFilePicker(); url: dom-window-showsavefilepicker
-    text: showDirectoryPicker(); url: dom-window-showdirectorypicker
-spec: idle-detection; urlPrefix: https://wicg.github.io/idle-detection/
-  type: method; for: IdleDetector
-    text: requestPermission(); url: api-idledetector-requestpermission
-    text: start(); url: api-idledetector-start
-spec: clipboard-apis; urlPrefix: https://w3c.github.io/clipboard-apis/
-  type: method; for: Clipboard
-    text: read(); url: dom-clipboard-read
-    text: readText(); url: dom-clipboard-readtext
-    text: write(); url: dom-clipboard-write
-    text: writeText(); url: dom-clipboard-writetext
-spec: screen-wake-lock; urlPrefix: https://w3c.github.io/screen-wake-lock/
-  type: method; for: WakeLock
-    text: request(); url: the-request-method
-spec: web-nfc; urlPrefix: https://w3c.github.io/web-nfc/
-  type: method; for: NDEFReader
-    text: write(); url: dom-ndefreader-write
-    text: scan(); url: dom-ndefreader-scan
 spec: battery; urlPrefix: https://w3c.github.io/battery/
-  type: method; for: Navigator
-    text: getBattery(); url: dom-navigator-getbattery
   type: dfn
-    text: battery promise; url: dfn-battery-promise
-spec: pointerlock; urlPrefix: https://w3c.github.io/pointerlock/
-  type: method; for: Element
-    text: requestPointerLock(options); url: #dfn-requestpointerlock-pointerlockoptions-options
-spec: screen-orientation; urlPrefix: https://w3c.github.io/screen-orientation/
-  type: dfn
-    text: apply an orientation lock; url: dfn-apply-an-orientation-lock
-    text: pre-lock conditions; url: dfn-pre-lock-conditions
-  type: method; for: ScreenOrientation
-    text: lock(); url: dom-screenorientation-lock
-    text: unlock(); url: dom-screenorientation-unlock
-spec: gamepad; urlPrefix: https://w3c.github.io/gamepad/
-  type: method; for: Navigator
-    text: getGamepads(); url: dom-navigator-getgamepads
-  type: event; for: Window
-    text: gamepadconnected; url: dfn-gamepadconnected
-    text: gamepaddisconnected; url: dfn-gamepaddisconnected
-  type: interface
-    text: Gamepad; url: dom-gamepad
-    text: GamepadEvent; url: dom-gamepadevent
-  type: attribute; for: GamepadEvent
-    text: gamepad; url: dom-gamepadevent-gamepad
+    text: [[BatteryPromise]]; url: dfn-batterypromise
 spec: picture-in-picture; urlPrefix: https://w3c.github.io/picture-in-picture/
   type: dfn
     text: request Picture-in-Picture; url: request-picture-in-picture-algorithm
-  type: attribute; for: HTMLVideoElement
-    text: autoPictureInPicture; url: dom-htmlvideoelement-requestpictureinpicture
-  type: method; for: HTMLVideoElement
-    text: requestPictureInPicture(); url: dom-htmlvideoelement-autopictureinpicture
-spec: navigation-timing; urlPrefix: https://w3c.github.io/navigation-timing/
-  type: dfn
-    text: current document; url: dfn-current-document
-spec: encrypted-media; urlPrefix: https://w3c.github.io/encrypted-media/
-  type: method; for: Navigator
-    text: requestMediaKeySystemAccess(keySystem, supportedConfigurations); url: requestMediaKeySystemAccess
 spec: mediacapture-main; urlPrefix: https://w3c.github.io/mediacapture-main/
   type: dfn
     text: device change notification steps; url: dfn-device-change-notification-steps
-spec: hid; urlPrefix: https://wicg.github.io/webhid/
-  type: interface
-    text: HID; url: hid-interface
-  type: method; for: HID
-    text: getDevices(); url: dom-hid-getdevices
-  type: method; for: HID
-    text: requestDevice(); url: dom-hid-requestdevice
-spec: backgroud-fetch; urlPrefix: https://wicg.github.io/background-fetch/
-  type: interface
-    text: BackgroundFetchManager; url: backgroundfetchmanager
-  type: method; for: BackgroundFetchManager
-    text: fetch(); url: dom-backgroundfetchmanager-fetch
-spec: push-api; urlPrefix: https://w3c.github.io/push-api/
-  type: interface
-    text: PushManager; url: dom-pushmanager
-  type: method; for: PushManager
-    text: subscribe(); url: dom-pushmanager-subscribe
-spec: screen-capture; urlPrefix: https://w3c.github.io/mediacapture-screen-share
-  type: method; for: MediaDevices
-    text: getDisplayMedia(); url: dom-mediadevices-getdisplaymedia
-spec: audio-output; urlPrefix: https://w3c.github.io/mediacapture-output/
-  type: method; for: MediaDevices
-    text: selectAudioOutput(); url: dom-mediadevices-selectaudiooutput
-spec: speech-api; urlPrefix: https://wicg.github.io/speech-api/
-  type: interface
-    text: SpeechSynthesis; url: speechsynthesis
-  type: method; for: SpeechSynthesis
-    text: speak(utterance); url: dom-speechsynthesis-speak
-    text: cancel(); url: dom-speechsynthesis-cancel
-    text: pause(); url: dom-speechsynthesis-pause
-    text: resume(); url: dom-speechsynthesis-resume
-    text: getVoices(); url: dom-speechsynthesis-getvoices
-  type: interface
-    text: SpeechRecognition; url: speechrecognition
-  type: method; for: SpeechRecognition
-    text: start(); url: dom-speechrecognition-start
-    text: stop(); url: dom-speechrecognition-stop
-    text: abort(); url: dom-speechrecognition-abort
-spec: web-locks; urlPrefix: https://w3c.github.io/web-locks/
-  type: method; for: LockManager
-    text: request(); url:dom-lockmanager-request
-    text: query(); url:dom-lockmanager-query
-spec: service-workers; urlPrefix: https://w3c.github.io/ServiceWorker/
-  type: interface
-    text: ServiceWorkerRegistration; url: serviceworkerregistration-interface
-  type: method; for: ServiceWorkerRegistration
-    text: update(); url: dom-serviceworkerregistration-update
-    text: unregister(); url: dom-serviceworkerregistration-unregister
-  type: interface
-    text: ServiceWorkerContainer; url: serviceworkercontainer-interface
-  type: method; for: ServiceWorkerContainer
-    text: register(scriptURL, options); url: dom-serviceworkercontainer-register
-  type: interface
-    text: ServiceWorker; url: serviceworker-interface
-  type: method: for: ServiceWorker
-    text: postMessage(message, transfer); url: dom-serviceworker-postmessage
-    text: postMessage(message, options); url: service-worker-postmessage-options
 spec: nav-speculation; urlPrefix: prefetch.html
   type: dfn
     text: supports prefetch; url: supports-prefetch
@@ -781,9 +644,9 @@ Add {{[DelayWhilePrerendering]}} to {{BroadcastChannel/postMessage()}}.
 
   1. If [=this=]'s [=relevant global object=]'s [=Window/navigable=] is a [=prerendering navigable=], then:
 
-    1. Let |watchProcessId| be a new unique <a spec=GEOLOCATION>watch process</a> ID, and note it as a <dfn>post-prerendering activation geolocation watch process ID</dfn>.
+    1. Let |watchId| be an [=implementation-defined=] {{unsigned long}}, and note it as a <dfn>post-prerendering activation geolocation watch process ID</dfn>.
 
-    1. Append the following steps to [=this=]'s [=platform object/post-prerendering activation steps list=], with the modification that the <a spec=GEOLOCATION>watch process</a> generated must use |watchProcessId| as its ID, and return |watchProcessId|.
+    1. Append the following steps to [=this=]'s [=platform object/post-prerendering activation steps list=], with the modification that the |watchId| generated must use |watchId| as its ID, and return |watchId|.
 </div>
 
 <div algorithm="Geolocation clearWatch patch">
@@ -865,13 +728,13 @@ Add {{[DelayWhilePrerendering]}} to {{NDEFReader/write()}} and {{NDEFReader/scan
 <div algorithm="Navigator getBattery patch">
   Modify the {{Navigator/getBattery()}} method steps by prepending the following step:
 
-  1. If [=this=]'s [=relevant global object=]'s [=Window/navigable=] is a [=prerendering navigable=], then append the following steps to [=this=]'s [=platform object/post-prerendering activation steps list=] and return [=this=]'s [=battery promise=].
+  1. If [=this=]'s [=relevant global object=]'s [=Window/navigable=] is a [=prerendering navigable=], then append the following steps to [=this=]'s [=platform object/post-prerendering activation steps list=] and return [=this=].[=[[BatteryPromise]]=].
 </div>
 
 <h4 id="patch-orientation-lock">Screen Orientation API</h4>
 
-<div algorithm="apply an orientation lock patch">
-  Modify the [=apply an orientation lock=] algorithm steps by overwriting the first few steps, before it goes [=in parallel=], as follows:
+<div algorithm="apply orientation lock patch">
+  Modify the <a spec="SCREEN-ORIENTATION">apply orientation lock</a> algorithm steps by overwriting the first few steps, before it goes [=in parallel=], as follows:
 
   1. Let |promise| be a new promise.
 
@@ -879,7 +742,7 @@ Add {{[DelayWhilePrerendering]}} to {{NDEFReader/write()}} and {{NDEFReader/scan
 
   1. If the [=user agent=] does not support locking the screen orientation, then [=reject=] |promise| with a "{{NotSupportedError}}" {{DOMException}} and return |promise|.
 
-  1. If the [=document=]'s [=Document/active sandboxing flag set=] has the [=sandboxed orientation lock browsing context flag=] set, or the [=user agent=] doesn't meet the [=pre-lock conditions=] to perform an orientation change, then [=reject=] |promise| with a "{{SecurityError}}" {{DOMException}} and return |promise|.
+  1. If the [=document=]'s [=Document/active sandboxing flag set=] has the [=sandboxed orientation lock browsing context flag=] set, or the [=user agent=] doesn't meet the <a spec="SCREEN-ORIENTATION">pre-lock conditions</a> to perform an orientation change, then [=reject=] |promise| with a "{{SecurityError}}" {{DOMException}} and return |promise|.
 
   1. Set the [=document=]'s \[[orientationPendingPromise]] to |promise|.
 </div>
@@ -897,13 +760,13 @@ Add {{[DelayWhilePrerendering]}} to {{ScreenOrientation/unlock()}}.
 </div>
 
 <p algorithm="gamepad events patch">
-  Modify the discussion of the {{Window/gamepadconnected}} and {{Window/gamepaddisconnected}} events to specify that the user agent must not dispatch these events if the {{Window}} object's [=Window/navigable=] is a [=prerendering navigable=].
+  Modify the discussion of the {{gamepadconnected}} and {{gamepaddisconnected}} events to specify that the user agent must not dispatch these events if the {{Window}} object's [=Window/navigable=] is a [=prerendering navigable=].
 </p>
 
 <div algorithm="gamepadconnected post-prerendering">
-  Modify the {{Window/gamepadconnected}} section to indicate that every {{Document}} |document|'s [=Document/post-prerendering activation steps list=] should gain the following steps:
+  Modify the {{gamepadconnected}} section to indicate that every {{Document}} |document|'s [=Document/post-prerendering activation steps list=] should gain the following steps:
 
-  1. If |document| is [=allowed to use=] the "`gamepad`" feature, and |document|'s [=relevant settings object=] is a [=secure context=], and any gamepads are connected, then for each connected gamepad, [=fire an event=] named {{Window/gamepadconnected}} at |document|'s [=relevant global object=] using {{GamepadEvent}}, with its {{GamepadEvent/gamepad}} attribute initialized to a new {{Gamepad}} object representing the connected gamepad.
+  1. If |document| is [=allowed to use=] the "`gamepad`" feature, and |document|'s [=relevant settings object=] is a [=secure context=], and any gamepads are connected, then for each connected gamepad, [=fire an event=] named {{gamepadconnected}} at |document|'s [=relevant global object=] using {{GamepadEvent}}, with its {{GamepadEvent/gamepad}} attribute initialized to a new {{Gamepad}} object representing the connected gamepad.
 </div>
 
 <h4 id="eme-patch">Encrypted Media Extensions</h4>
@@ -968,7 +831,7 @@ Add {{[DelayWhilePrerendering]}} to {{SpeechRecognition/start()}}, {{SpeechRecog
 
 <h4 id="web-locks-patch">Web Locks API</h4>
 
-Add {{[DelayWhilePrerendering]}} to {{LockManager/request()}} and {{LockManager/query()}}.
+Add {{[DelayWhilePrerendering]}} to {{LockManager/request(name, callback)}}, {{LockManager/request(name, options, callback)}}, and {{LockManager/query()}}.
 
 <h3 id="implicitly-restricted">Implicitly restricted APIs</h3>
 
@@ -996,10 +859,10 @@ APIs that require [=transient activation=] or [=sticky activation=]:
 - {{MediaDevices/getDisplayMedia()}} [[SCREEN-CAPTURE]]
 
 APIs that require [=top-level traversable/system focus=]:
-- The Asynchronous Clipboard API: {{Clipboard/read()|navigator.clipboard.read()}}, {{Clipboard/readText()|navigator.clipboard.readText()}}, {{Clipboard/write()|navigator.clipboard.write()}}, {{Clipboard/writeText|navigator.clipboard.writeText()}}. [[CLIPBOARD-APIS]]
+- The Asynchronous Clipboard API: {{Clipboard/read()|navigator.clipboard.read()}}, {{Clipboard/readText()|navigator.clipboard.readText()}}, {{Clipboard/write()|navigator.clipboard.write()}}, {{Clipboard/writeText()|navigator.clipboard.writeText()}}. [[CLIPBOARD-APIS]]
 
 APIs that require the "<code>visible</code>" [=Document/visibility state=]:
 - {{WakeLock/request()|navigator.wakeLock.request()}} [[SCREEN-WAKE-LOCK]]
 
 More complicated cases:
-- [=Request Picture-in-Picture=] as invoked due to {{HTMLVideoElement/requestPictureInPicture()|video.requestPictureInPicture()}} or {{HTMLVideoElement/autoPictureInPicture}} requires either [=transient activation=], or the [=Document/visibility state=] to have been "<code>visible</code>". [[PICTURE-IN-PICTURE]]
+- [=Request Picture-in-Picture=] as invoked due to {{HTMLVideoElement/requestPictureInPicture()|video.requestPictureInPicture()}} requires either [=transient activation=], or the [=Document/visibility state=] to have been "<code>visible</code>". [[PICTURE-IN-PICTURE]]

--- a/speculation-rules.bs
+++ b/speculation-rules.bs
@@ -51,11 +51,6 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
     urlPrefix: links.html
       for: a/rel
         text: noreferrer; url: link-type-noreferrer
-spec: urlpattern; urlPrefix: https://wicg.github.io/urlpattern/
-  type: interface; text: URLPattern; url: urlpattern
-  type: constructor; for: URLPattern; text: "URLPattern(input, baseURL)"; url: dom-urlpattern-urlpattern
-  type: dictionary; text: URLPatternInit
-  type: dfn; text: match; url: match
 spec: RFC8941; urlPrefix: https://httpwg.org/specs/rfc8941.html
   type: dfn
     text: structured header; url: top
@@ -461,8 +456,7 @@ A [=document=] has a <dfn for=document export>list of speculation rule sets</dfn
 
 A [=document=] has a <dfn for=document export>list of pending external speculation rule resources</dfn>, which is an initially empty [=list=] of [=pending external speculation rule resources=].
 
-<!-- TODO(domfarolino): Get rid of the `data-link-type="interface"` once we fix the dfn in HTML. -->
-Periodically, for any [=document=] |document|, the user agent may [=queue a global task=] on the <a data-link-type="interface">DOM manipulation task source</a> with |document|'s [=relevant global object=] to [=consider speculation=] for |document|.
+Periodically, for any [=document=] |document|, the user agent may [=queue a global task=] on the [=DOM manipulation task source=] with |document|'s [=relevant global object=] to [=consider speculation=] for |document|.
 
 <p class="note">
   The user agent will likely do when resources are idle and available, or otherwise the circumstances of its previous decision whether to start a speculation could have changed.


### PR DESCRIPTION
Fixes #231. Takes care of most of #232, which is largely due to other specs changing from under use while we monkeypatch them. Notable changes:

* Geolocation no longer uses the "watch process" concept.
* autoPictureInPicture was removed from HTMLVideoElement.

Many of these changes are just removing anchors blocks which are no longer necessary, due to Bikeshed's new WebRef integration meaning that ReSpec specs are now in the database.