### PR TITLE
Remove mentions of prefetch-src

### DIFF
--- a/prefetch.bs
+++ b/prefetch.bs
@@ -602,9 +602,6 @@ The <dfn>list of sufficiently strict speculative navigation referrer policies</d
         :  [=session history entry/document state=]
         :: |documentState|
     1. Let |request| be the result of [=creating a navigation request=] given |entry|, |document|'s [=relevant settings object=], |document|'s [=node navigable=]'s [=navigable/container=], and false.
-    1. Set |request|'s [=request/initiator=] to "`prefetch`".
-
-        <div class="note">This causes the `prefetch-src` [[CSP]] directive to apply as part of [=fetch=].</div>
     1. If |prefetchRecord|'s [=prefetch record/partition state=] is a [=cross-partition prefetch state=]:
         1. Clear |request|'s [=request/use-URL-credentials flag=].
         1. Set |request|'s [=request/cache mode=] to "`no-store`".

--- a/prerendering-same-site.md
+++ b/prerendering-same-site.md
@@ -262,7 +262,7 @@ Generally speaking, our plan is to treat content as if it were in a "background 
 
 A prerendered `Document` can apply CSP to itself as normal. Being in a prerendering browsing context vs. a normal top-level browsing context does not change any of the impacts of CSP. Note that since prerendered documents are [always loaded from HTTP(S) URLs](#restrictions-on-loaded-content), there is no need to worry about complex CSP inheritance semantics.
 
-Prerendered content will be affected by [`prefetch-src`](https://w3c.github.io/webappsec-csp/#directive-prefetch-src) on the referring page, which provides a way of preventing prefetching in addition to the [triggers](./triggers.md).
+If a referrer page wants to protect maliciously-injected content from performing prerenders (as a form of [exfiltration protection](http://www.cse.chalmers.se/research/group/security/pdf/data-exfiltration-in-the-face-of-csp.pdf)), it can use `default-src`.
 
 ## More details on cross-origin same-site
 

--- a/speculation-rules.bs
+++ b/speculation-rules.bs
@@ -616,7 +616,7 @@ This specification causes activity in response to content found in the document,
 
 Such an attacker is otherwise able to inject JavaScript, frames or other elements. The activity possible with this specification (requesting fetches etc) is generally less dangerous than arbitrary script execution, and comparable to other elements. It would, however, make it possible to cause prefetches of links in the document, and the existence of those prefetches could provide a vector for exfiltrating information about those links.
 
-The same mitigations available to other features also apply here. In particular, the [[CSP]] `script-src` directive applies to the parsing of the speculation rules and the `prefetch-src` directive applies to prefetch requests arising from the rules.
+The same mitigations available to other features also apply here. In particular, the [[CSP]] `script-src` directive applies to the parsing of the speculation rules and the `default-src` directive applies to prefetch requests arising from the rules.
 
 The possibility of leaking link URLs via this mechanism is additionally mitigated by the fact that prefetch and prerender to plaintext HTTP (other than to localhost) is not permitted, and so such an on-path attacker could not directly observe preloading request URLs, but would only have access to metadata and traffic analysis. This does not, however, replace standard XSS protections.
 

--- a/triggers.md
+++ b/triggers.md
@@ -283,10 +283,9 @@ For document rules, `"relative_to"` can be paired directly with `"href_matches"`
 
 ### Content-Security-Policy
 
-Speculation rules can be embedded inline within a `script` tag with `type="speculationrules"`, and restricted by the `script-src` and `script-src-elem` CSP directive.
-To allow inline speculation rules, use either the `'inline-speculation-rules'` or `'unsafe-inline'` keyword.
-Using `script-src 'inline-speculation-rules'` or `script-src-elem 'inline-speculation-rules'` helps developers to permit inline speculation rules but still disallow unsafe inline JavaScript.
-The `prefetch-src` directive can be used to restrict which URLs can be prefetched or prerendered.
+Speculation rules can be embedded inline within a `script` tag with `type="speculationrules"`, and restricted by the `script-src` and `script-src-elem` CSP directive. To allow inline speculation rules, use either the `'inline-speculation-rules'` or `'unsafe-inline'` keyword. Using `script-src 'inline-speculation-rules'` or `script-src-elem 'inline-speculation-rules'` helps developers to permit inline speculation rules but still disallow unsafe inline JavaScript.
+
+The `default-src` directive can be used to restrict which URLs can be prefetched or prerendered.
 
 ### Eagerness
 


### PR DESCRIPTION
Since it no longer exists, default-src is the only mechanism for preventing prefetches.

Closes #235.

Probably #237 needs to merge first to fix the build.