### PR TITLE
Use element's root instead of document as scoping root

### DIFF
--- a/speculation-rules.bs
+++ b/speculation-rules.bs
@@ -593,7 +593,7 @@ A <dfn>prerender candidate</dfn> is a [=struct=] with the following [=struct/ite
     1. Return false.
   1. If |predicate| is a [=document rule CSS selector predicate=], then:
     1. [=list/For each=] |selector| of |predicate|'s [=document rule CSS selector predicate/selectors=]:
-      1. [=match a selector against an element|Match=] |selector| against |el| with the [=scoping root=] set to |el|'s [=Node/node document=]. If the result is true, return true.
+      1. [=match a selector against an element|Match=] |selector| against |el| with the [=scoping root=] set to |el|'s [=tree/root=]. If the result is true, return true.
 
         During this step, user agents must apply the same privacy restrictions to the '':visited'' pseudo-class as they would to other selector matching logic that could be observed by authors (e.g., {{ParentNode/querySelector(selectors)}}).
 


### PR DESCRIPTION
Fixes #240. 