### PR TITLE
Fix LINK ERROR on Multiple possible refs on selector and identifier

### DIFF
--- a/speculation-rules.bs
+++ b/speculation-rules.bs
@@ -21,8 +21,10 @@ spec:html; type:element-attr; for:a; text:referrerpolicy
 spec:html; type:element-attr; for:a; text:rel
 spec:html; type:element; text:link
 spec:html; type:element; text:script
+spec:selectors-4; type:dfn; text:selector
 spec:selectors-4; type:selector; text::link
 spec:selectors-4; type:selector; text::visited
+spec:webidl; type:dfn; text:identifier
 </pre>
 <pre class="anchors">
 spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/


### PR DESCRIPTION
These errors seem introduced by other spec changes, and this patch clarifies which should be used in this spec.