### PR TITLE
Fix the spec build.

### DIFF
--- a/no-vary-search.bs
+++ b/no-vary-search.bs
@@ -125,17 +125,20 @@ The [=obtain a URL search variance=] algorithm ensures that all [=URL search var
         <th>Result</th>
     <tbody>
       <tr>
-        <td><pre highlight="http">No-Vary-Search: params</pre>
+        <td>
+          <pre highlight="http">No-Vary-Search: params</pre>
         <td>
           * [=URL search variance/no-vary params=]: [=URL search variance/no-vary params/wildcard=]
           * [=URL search variance/vary params=]: (empty list)
       <tr>
-        <td><pre highlight="http">No-Vary-Search: params=("a")</pre>
+        <td>
+          <pre highlight="http">No-Vary-Search: params=("a")</pre>
         <td>
           * [=URL search variance/no-vary params=]: « "`a`" »
           * [=URL search variance/vary params=]:  [=URL search variance/vary params/wildcard=]
       <tr>
-        <td><pre highlight="http">No-Vary-Search: params, except=("x")</pre>
+        <td>
+          <pre highlight="http">No-Vary-Search: params, except=("x")</pre>
         <td>
           * [=URL search variance/no-vary params=]: [=URL search variance/no-vary params/wildcard=]
           * [=URL search variance/vary params=]: « "`x`" »
@@ -169,22 +172,31 @@ The [=obtain a URL search variance=] algorithm ensures that all [=URL search var
         <th>Conventional form
     <tbody>
       <tr>
-        <td><pre highlight="http">No-Vary-Search: params=?1</pre>
-        <td><pre highlight="http">No-Vary-Search: params</pre>
+        <td>
+          <pre highlight="http">No-Vary-Search: params=?1</pre>
+        <td>
+          <pre highlight="http">No-Vary-Search: params</pre>
       <tr>
-        <td><pre highlight="http">No-Vary-Search: key-order=?1</pre>
-        <td><pre highlight="http">No-Vary-Search: key-order</pre>
+        <td>
+          <pre highlight="http">No-Vary-Search: key-order=?1</pre>
+        <td>
+          <pre highlight="http">No-Vary-Search: key-order</pre>
       <tr>
-        <td><pre highlight="http">No-Vary-Search: params, key-order, except=("x")</pre>
-        <td><pre highlight="http">No-Vary-Search: key-order, params, except=("x")</pre>
+        <td>
+          <pre highlight="http">No-Vary-Search: params, key-order, except=("x")</pre>
+        <td>
+          <pre highlight="http">No-Vary-Search: key-order, params, except=("x")</pre>
       <tr>
-        <td><pre highlight="http">No-Vary-Search: params=?0</pre>
+        <td>
+          <pre highlight="http">No-Vary-Search: params=?0</pre>
         <td>(omit the header)
       <tr>
-        <td><pre highlight="http">No-Vary-Search: params=()</pre>
+        <td>
+          <pre highlight="http">No-Vary-Search: params=()</pre>
         <td>(omit the header)
       <tr>
-        <td><pre highlight="http">No-Vary-Search: key-order=?0</pre>
+        <td>
+          <pre highlight="http">No-Vary-Search: key-order=?0</pre>
         <td>(omit the header)
   </table>
 </div>

--- a/speculation-rules.bs
+++ b/speculation-rules.bs
@@ -690,17 +690,17 @@ The algorithm needs a patch to handle the "`script speculationrules`" type.
 
       2.  If <a>`type`</a> is "`script`", "`script attribute`" or "`navigation`"
           and |expression| matches the <a grammar>keyword-source</a>
-          "<a grammar>`'strict-dynamic'`</a>", return "`Does Not Allow`".
+          "<a grammar>`\'strict-dynamic'`</a>", return "`Does Not Allow`".
 
-          Note: `'strict-dynamic'` only applies to scripts, not other resource
+          Note: `\'strict-dynamic'` only applies to scripts, not other resource
           types. Usage is explained in more detail in [[CSP#strict-dynamic-usage]].
 
       3.  <ins>If <a>`type`</a> is "`script speculationrules`" and |expression| matches the
-          <a grammar>keyword-source</a> "<a grammar>`'inline-speculation-rules'`</a>",
+          <a grammar>keyword-source</a> "<a grammar>`\'inline-speculation-rules'`</a>",
           set `allow all inline` to `true`.</ins>
 
       4.  If |expression| is an <a>ASCII case-insensitive</a> match for the
-          <a grammar>`keyword-source`</a> "<a grammar>`'unsafe-inline'`</a>",
+          <a grammar>`keyword-source`</a> "<a grammar>`\'unsafe-inline'`</a>",
           set `allow all inline` to `true`.
 
 <h3 id="content-security-policy-patches-match-element-to-source-list">Does element match source list for type and source?</h3>
@@ -725,7 +725,7 @@ The algorithm needs patches to handle the "`script speculationrules`" type at th
 
       1.  If |expression| is an <a>ASCII case-insensitive</a> match for the
           <a grammar>`keyword-source`</a>
-          "<a grammar>`'unsafe-hashes'`</a>",
+          "<a grammar>`\'unsafe-hashes'`</a>",
           set |unsafe-hashes flag| to `true`. Break out of the loop.
 
   5.  If <a>`type`</a> is "`script`",<ins> "`script speculationrules`",</ins> "`style`",


### PR DESCRIPTION
(1) Apparently bikeshed now requires that `<pre>` be the first thing on
    the line. Not sure why.

(2) It is now necessary to backslash-escape the CSP 'foo' references
    because otherwise they are interpreted as CSS autolinks (since this
    file does have CSS markup shorthand enabled).