### PR TITLE
Remove speculation rule scores from future extensions

### DIFF
--- a/no-vary-search.md
+++ b/no-vary-search.md
@@ -388,14 +388,14 @@ For the preloading case, the fact that we don't know whether a preloaded page co
   "prefetch": [{
     "source": "list",
     "urls": ["/products"],
-    "score": 0.1
+    "eagerness": "conservative"
   }]
 }
 </script>
 <a href="/products?id=123">click me</a>
 ```
 
-Here, the `"score": 0.1` value is [meant to indicate](./triggers.md#scores) that the browser _may_ prefetch the given URL, and not that it _should_ prefetch the given URL. So, the browser probably won't prefetch `/products` on page load.
+Here, the conservative [eagerness](./triggers.md#eagerness) value indicates that the browser _may_ prefetch the given URL, and not that it _should_ prefetch the given URL. So, the browser probably won't prefetch `/products` on page load.
 
 But, let's say the user presses down on the link. Now it seems pretty likely that `/products?id=123` is going to be visited, so it might be a good time to prefetch `/products`. After all, `/products` might come back with `No-Vary-Search` indicating that the `id` query parameter is unimportant.
 
@@ -408,7 +408,7 @@ Also consider what happens if the headers for `/products` have not come back by 
 
 To solve this, we could have the speculation rules syntax provide a hint for what it expects the `No-Vary-Search` value to be. We would still have to verify the result (at least in cross-origin cases, for security; and proably in same-origin cases too, to avoid weird bugs). But it would help feed into the heuristics in such "may preload" cases.
 
-Any solution in this area is probably best thought through together with the design work on [document rules](./triggers.md#document-rules), [scores](./triggers.md#scores), and maybe [`No-Vary-Path`](#no-vary-path), since they would all likely be used together.
+Any solution in this area is probably best thought through together with the design work on [document rules](./triggers.md#document-rules), [eagerness](./triggers.md#eagerness), and maybe [`No-Vary-Path`](#no-vary-path), since they would all likely be used together.
 
 ### A `<meta>` version
 

--- a/triggers.md
+++ b/triggers.md
@@ -19,8 +19,8 @@
     - [Alternatives](#alternatives)
   - [Using the Document's base URL for external speculation rule sets](#using-the-documents-base-url-for-external-speculation-rule-sets)
   - [Content Security Policy](#content-security-policy)
+  - [Eagerness](#eagerness)
 - [Future extensions](#future-extensions)
-  - [Scores](#scores)
   - [Handler URLs](#handler-urls)
   - [External speculation rules via script elements](#external-speculation-rules-via-script-elements)
   - [More speculation actions](#more-speculation-actions)
@@ -289,9 +289,10 @@ The `default-src` directive can be used to restrict which URLs can be prefetched
 
 ### Eagerness
 
-Developers can control how eagerly the browser preloads links in order to balance the performance advantage against resource overhead.
+Developers may provide hints about how eagerly the browser should preload links in order to balance the performance advantage against resource overhead.
 This field accepts one of `"conservative"`, `"moderate"`  or `"eager"` strings as the value, and it is applicable to both `"prefetch"` and `"prerender"` actions and both `"list"` or `"document"` sources.
 If not specified, list rules default to `"eager"` and document rules default to `"conservative"`.
+The user agent takes this into consideration along with its own heuristics, so it may select a link that the author has indicated as less eager than another, if the less eager candidate is considered a better choice.
 
 ```json
 {
@@ -318,29 +319,6 @@ If not specified, list rules default to `"eager"` and document rules default to 
 ```
 
 ## Future extensions
-
-### Scores
-
-A rule may include a _score_ between 0.0 and 1.0 (inclusive), defaulting to 0.5, which is a hint about how likely the user is to navigate to the URL. It is expected that UAs will treat this monotonically (i.e., all else equal, increasing the score associated with a rule will make the UA speculate no less than before for that URL, and decreasing the score will not make the UA speculate where it previously did not). However, the user agent may select a link with a lower author-assigned score than another if its heuristics suggest it is a better choice.
-
-A modification of the above example, which works off of the highly-sophisticated model that people tend to click on the top-voted link more often than the later ones, would be:
-
-```json
-{"prefetch": [
-  {"source": "list",
-   "urls": ["/item?id=32480009"],
-   "score": 0.8},
-  {"source": "list",
-   "urls": [
-    "https://support.signal.org/hc/en-us/articles/4850133017242",
-    "https://discord.com/blog/how-discord-supercharges-network-disks-for-extreme-low-latency",
-    "https://github.com/containers/krunvm"
-   ],
-   "score": 0.5}
-]}
-```
-
-This might instead be more coarsely expressed, e.g., as an enumeration.
 
 ### Handler URLs
 


### PR DESCRIPTION
This idea has been superseded by the eagerness key.

The eagerness section of the explainer is also updated to better describe it as a hint instead of implying that the page can control the browser's heuristics.

We also update a No-Vary-Search example that was using a score key to use an equivalent eagerness value.