### PR TITLE
Add spec for No-Vary-Search hint in speculation rules

### DIFF
--- a/no-vary-search.bs
+++ b/no-vary-search.bs
@@ -22,6 +22,7 @@ spec: RFC8941; urlPrefix: https://www.rfc-editor.org/rfc/rfc8941.html
       text: dictionary; url: name-dictionaries
       text: boolean; url: name-boolean
       text: inner list; url: name-inner-lists
+    text: parsing structured fields; url: #text-parse
 </pre>
 <style>
 #example-equivalence-canonicalization table {
@@ -82,15 +83,14 @@ The [=obtain a URL search variance=] algorithm ensures that all [=URL search var
 <h2 id="parsing">Parsing</h2>
 
 <div algorithm>
-  To <dfn>obtain a URL search variance</dfn> given a [=response=] |response|:
+  To <dfn>parse a URL search variance</dfn> given a [=map=] |value|:
 
-  1. Let |value| be the result of [=header list/getting a structured field value=] given [:No-Vary-Search:] and "`dictionary`" from |response|'s [=response/header list=].
-  1. If |value| is null, then return the [=default URL search variance=].
-  1. If |value|'s [=map/keys=] [=list/contains=] anything other than "`key-order`", "`params`", or "`except`", then return the [=default URL search variance=].
+  1. If |value| is null, then return null.
+  1. If |value|'s [=map/keys=] [=list/contains=] anything other than "`key-order`", "`params`", or "`except`", then return null.
   1. Let |result| be a new [=URL search variance=].
   1. Set |result|'s [=URL search variance/vary on key order=] to true.
   1. If |value|["`key-order`"] [=map/exists=]:
-    1. If |value|["`key-order`"] is not a [=boolean=], then return the [=default URL search variance=].
+    1. If |value|["`key-order`"] is not a [=boolean=], then return null.
     1. Set |result|'s [=URL search variance/vary on key order=] to the boolean negation of |value|["`key-order`"].
   1. If |value|["`params`"] [=map/exists=]:
     1. If |value|["`params`"] is a [=boolean=]:
@@ -101,16 +101,26 @@ The [=obtain a URL search variance=] algorithm ensures that all [=URL search var
         1. Set |result|'s [=URL search variance/no-vary params=] to the empty list.
         1. Set |result|'s [=URL search variance/vary params=] to [=URL search variance/no-vary params/wildcard=].
     1. Otherwise, if |value|["`params`"] is a [=list=]:
-      1. If any [=list/item=] in |value|["`params`"] is not a [=string=], then return the [=default URL search variance=].
+      1. If any [=list/item=] in |value|["`params`"] is not a [=string=], then return null.
       1. Set |result|'s [=URL search variance/no-vary params=] to the result of applying [=parse a key=] to each [=list/item=] in |value|["`params`"].
       1. Set |result|'s [=URL search variance/vary params=] to [=URL search variance/no-vary params/wildcard=].
-    1. Otherwise, return the [=default URL search variance=].
+    1. Otherwise, return null.
   1. If |value|["`except`"] [=map/exists=]:
-    1. If |value|["`params`"] is not true, then return the [=default URL search variance=].
-    1. If |value|["`except`"] is not a [=list=], then return the [=default URL search variance=].
-    1. If any [=list/item=] in |value|["`except`"] is not a [=string=], then return the [=default URL search variance=].
+    1. If |value|["`params`"] is not true, then return null.
+    1. If |value|["`except`"] is not a [=list=], then return null.
+    1. If any [=list/item=] in |value|["`except`"] is not a [=string=], then return null.
     1. Set |result|'s [=URL search variance/vary params=] to the result of applying [=parse a key=] to each [=list/item=] in |value|["`except`"].
   1. Return |result|.
+
+</div>
+
+<div algorithm>
+  To <dfn>obtain a URL search variance</dfn> given a [=response=] |response|:
+
+  1. Let |fieldValue| be the result of [=header list/getting a structured field value=] given [:No-Vary-Search:] and "`dictionary`" from |response|'s [=response/header list=].
+  1. Let |result| be the result of [=parsing a URL search variance=] given |fieldValue|.
+  1. If |result| is null, then return the [=default URL search variance=].
+  1. Otherwise return |result|.
 
   <p class="note">In general, this algorithm is strict and tends to return the [=default URL search variance=] whenever it sees something it doesn't recognize. This is because the [=default URL search variance=] behavior will just cause fewer cache hits, which is an acceptable fallback behavior.
 </div>
@@ -187,6 +197,18 @@ The [=obtain a URL search variance=] algorithm ensures that all [=URL search var
         <td><pre highlight="http">No-Vary-Search: key-order=?0</pre>
         <td>(omit the header)
   </table>
+</div>
+
+<div algorithm>
+  To <dfn>obtain a URL search variance hint</dfn> given a [=string=] |hintValue|:
+
+  1. Let |fieldValue| be the result of [=parsing structured fields=] given |hintValue| and "`dictionary`".
+  1. If parsing failed, then return null.
+  1. Let |result| be the result of [=parsing a URL search variance=] given |fieldValue|.
+  1. If |result| is null, then return null.
+  1. Otherwise return |result|.
+
+  <p class="note">Speculation rule parsing is strict, so the return value of this algorithm surfaces parsing errors instead of silently returning the [=default URL search variance=].
 </div>
 
 <div algorithm>

--- a/no-vary-search.bs
+++ b/no-vary-search.bs
@@ -85,12 +85,12 @@ The [=obtain a URL search variance=] algorithm ensures that all [=URL search var
 <div algorithm>
   To <dfn>parse a URL search variance</dfn> given a [=map=] |value|:
 
-  1. If |value| is null, then return null.
-  1. If |value|'s [=map/keys=] [=list/contains=] anything other than "`key-order`", "`params`", or "`except`", then return null.
+  1. If |value| is null, then return the [=default URL search variance=].
+  1. If |value|'s [=map/keys=] [=list/contains=] anything other than "`key-order`", "`params`", or "`except`", then return the [=default URL search variance=].
   1. Let |result| be a new [=URL search variance=].
   1. Set |result|'s [=URL search variance/vary on key order=] to true.
   1. If |value|["`key-order`"] [=map/exists=]:
-    1. If |value|["`key-order`"] is not a [=boolean=], then return null.
+    1. If |value|["`key-order`"] is not a [=boolean=], then return the [=default URL search variance=].
     1. Set |result|'s [=URL search variance/vary on key order=] to the boolean negation of |value|["`key-order`"].
   1. If |value|["`params`"] [=map/exists=]:
     1. If |value|["`params`"] is a [=boolean=]:
@@ -101,28 +101,26 @@ The [=obtain a URL search variance=] algorithm ensures that all [=URL search var
         1. Set |result|'s [=URL search variance/no-vary params=] to the empty list.
         1. Set |result|'s [=URL search variance/vary params=] to [=URL search variance/no-vary params/wildcard=].
     1. Otherwise, if |value|["`params`"] is a [=list=]:
-      1. If any [=list/item=] in |value|["`params`"] is not a [=string=], then return null.
+      1. If any [=list/item=] in |value|["`params`"] is not a [=string=], then return the [=default URL search variance=].
       1. Set |result|'s [=URL search variance/no-vary params=] to the result of applying [=parse a key=] to each [=list/item=] in |value|["`params`"].
       1. Set |result|'s [=URL search variance/vary params=] to [=URL search variance/no-vary params/wildcard=].
-    1. Otherwise, return null.
+    1. Otherwise, return the [=default URL search variance=].
   1. If |value|["`except`"] [=map/exists=]:
-    1. If |value|["`params`"] is not true, then return null.
-    1. If |value|["`except`"] is not a [=list=], then return null.
-    1. If any [=list/item=] in |value|["`except`"] is not a [=string=], then return null.
+    1. If |value|["`params`"] is not true, then return the [=default URL search variance=].
+    1. If |value|["`except`"] is not a [=list=], then return the [=default URL search variance=].
+    1. If any [=list/item=] in |value|["`except`"] is not a [=string=], then return the [=default URL search variance=].
     1. Set |result|'s [=URL search variance/vary params=] to the result of applying [=parse a key=] to each [=list/item=] in |value|["`except`"].
   1. Return |result|.
 
+  <p class="note">In general, this algorithm is strict and tends to return the [=default URL search variance=] whenever it sees something it doesn't recognize. This is because the [=default URL search variance=] behavior will just cause fewer cache hits, which is an acceptable fallback behavior.
 </div>
 
 <div algorithm>
   To <dfn>obtain a URL search variance</dfn> given a [=response=] |response|:
 
   1. Let |fieldValue| be the result of [=header list/getting a structured field value=] given [:No-Vary-Search:] and "`dictionary`" from |response|'s [=response/header list=].
-  1. Let |result| be the result of [=parsing a URL search variance=] given |fieldValue|.
-  1. If |result| is null, then return the [=default URL search variance=].
-  1. Otherwise return |result|.
+  1. Return the result of [=parsing a URL search variance=] given |fieldValue|.
 
-  <p class="note">In general, this algorithm is strict and tends to return the [=default URL search variance=] whenever it sees something it doesn't recognize. This is because the [=default URL search variance=] behavior will just cause fewer cache hits, which is an acceptable fallback behavior.
 </div>
 
 <div class="example" id="example-parsing-vary-vs-no-vary">
@@ -203,12 +201,9 @@ The [=obtain a URL search variance=] algorithm ensures that all [=URL search var
   To <dfn>obtain a URL search variance hint</dfn> given a [=string=] |hintValue|:
 
   1. Let |fieldValue| be the result of [=parsing structured fields=] given |hintValue| and "`dictionary`".
-  1. If parsing failed, then return null.
-  1. Let |result| be the result of [=parsing a URL search variance=] given |fieldValue|.
-  1. If |result| is null, then return null.
-  1. Otherwise return |result|.
+  1. If parsing failed, then return the [=default URL search variance=].
+  1. Return the result of [=parsing a URL search variance=] given |fieldValue|.
 
-  <p class="note">Speculation rule parsing is strict, so the return value of this algorithm surfaces parsing errors instead of silently returning the [=default URL search variance=].
 </div>
 
 <div algorithm>

--- a/prefetch.bs
+++ b/prefetch.bs
@@ -200,7 +200,7 @@ A <dfn export>prefetch record</dfn> is a [=struct=] with the following [=struct/
 * <dfn export for="prefetch record">fetch controller</dfn>, a [=fetch controller=] (a new [=fetch controller=] by default)
 * <dfn export for="prefetch record">sandboxing flag set</dfn>, a [=sandboxing flag set=]
 * <dfn export for="prefetch record">redirect chain</dfn>, a [=redirect chain=] (empty by default)
-* <dfn export for="prefetch record">creation time</dfn>, a {{DOMHighResTimeStamp}} (0.0 by default)
+* <dfn export for="prefetch record">start time</dfn>, a {{DOMHighResTimeStamp}} (0.0 by default)
 * <dfn export for="prefetch record">expiry time</dfn>, a {{DOMHighResTimeStamp}} (0.0 by default)
 * <dfn export for="prefetch record">source partition key</dfn>, a [=network partition key=] or null (the default)
 * <dfn export for="prefetch record">isolated partition key</dfn>, a [=network partition key=] whose first item is an [=opaque origin=] and which represents a separate partition in which cross-partition state can be temporarily stored, or null (the default)
@@ -212,7 +212,7 @@ A <dfn export>prefetch record</dfn> is a [=struct=] with the following [=struct/
 
 A [=prefetch record=]'s <dfn export for="prefetch record">response</dfn> is the [=exchange record/response=] of the last element of its [=prefetch record/redirect chain=], or null if that list [=list/is empty=].
 
-The user agent may [=prefetch record/cancel and discard=] records from the [=Document/prefetch records=] even if they are not expired, e.g., due to resource constraints. Since completed records with expiry times in the past will never be [=find a matching prefetch record|matching prefetch records=], they can be removed with no observable consequences.
+The user agent may [=prefetch record/cancel and discard=] records from the [=Document/prefetch records=] even if they are not expired, e.g., due to resource constraints. Since completed records with expiry times in the past will never be [=wait for a matching prefetch record|matching prefetch records=], they can be removed with no observable consequences.
 
 <div algorithm>
     A [=prefetch record=] |prefetchRecord| <dfn export for="prefetch record">matches a URL</dfn> given a [=URL=] |url| if the following algorithm returns true:
@@ -224,7 +224,7 @@ The user agent may [=prefetch record/cancel and discard=] records from the [=Doc
 </div>
 
 <div algorithm>
-    A [=prefetch record=] |prefetchRecord| <dfn export for="prefetch record">possibly matches a URL</dfn> given a [=URL=] |url| if the following algorithm returns true:
+    A [=prefetch record=] |prefetchRecord| <dfn export for="prefetch record">is expected to match a URL</dfn> given a [=URL=] |url| if the following algorithm returns true:
     1. If |prefetchRecord| [=prefetch record/matches a URL=] given |url|, return true.
     1. If |prefetchRecord|'s [=prefetch record/response=] is null:
       1. Let |searchVariance| be |prefetchRecord|'s [=prefetch record/No-Vary-Search hint=].
@@ -250,11 +250,11 @@ The user agent may [=prefetch record/cancel and discard=] records from the [=Doc
     1. [=Assert=]: |document| is [=Document/fully active=].
     1. Let |currentTime| be the [=current high resolution time=] for the [=relevant global object=] of |document|.
     1. Let |expiryTime| be |currentTime| + 300000 (i.e., five minutes).
-    1. [=list/Remove=] all elements of |document|'s [=Document/prefetch records=] which [=prefetch record/match a URL=] given |prefetchRecord|'s [=prefetch record/URL=] and whose [=prefetch record/state=] equals "`completed`".
+    1. [=list/Remove=] all elements of |document|'s [=Document/prefetch records=] which have the same [=prefetch record/URL=] as |prefetchRecord| and whose [=prefetch record/state=] equals "`completed`".
     1. Set |prefetchRecord|'s [=prefetch record/state=] to "`completed`" and [=prefetch record/expiry time=] to |expiryTime|.
 </div>
 
-<div algorithm="find a matching complete prefetch record">
+<div algorithm>
     To <dfn export>find a matching complete prefetch record</dfn> given a {{Document}} |document|, [=URL=] |url|, and [=sandboxing flag set=] |sandboxFlags|, perform the following steps.
 
     1. [=Assert=]: |document| is [=Document/fully active=].
@@ -286,8 +286,8 @@ The user agent may [=prefetch record/cancel and discard=] records from the [=Doc
     <p class="issue">It might be possible to use cache response headers to determine when a response can be used multiple times, but given the short lifetime of the prefetch buffer it's unclear whether this is worthwhile.</p>
 </div>
 
-<div algorithm="find a matching prefetch record">
-    To <dfn export>find a matching prefetch record</dfn> given a {{Document}} |document|, [=URL=] |url|, and [=sandboxing flag set=] |sandboxFlags|, perform the following steps.
+<div algorithm>
+    To <dfn export>wait for a matching prefetch record</dfn> given a {{Document}} |document|, [=URL=] |url|, and [=sandboxing flag set=] |sandboxFlags|, perform the following steps.
 
     1. [=Assert=]: this is running [=in parallel=].
     1. Let |cutoffTime| be null.
@@ -298,11 +298,10 @@ The user agent may [=prefetch record/cancel and discard=] records from the [=Doc
         1. [=list/For each=] |record| of |document|'s [=Document/prefetch records=]:
             1. If all of the following are true, then [=list/append=] |record| to |potentialRecords|:
                 * |record|'s [=prefetch record/state=] is "`ongoing`".
-                * |record| [=prefetch record/possibly matches a URL=] given |url|.
+                * |record| [=prefetch record/is expected to match a URL=] given |url|.
                 * |record|'s [=prefetch record/sandboxing flag set=] is not empty or |sandboxFlags| is empty.
                 * |record|'s [=prefetch record/expiry time=] is greater than the [=current high resolution time=] for the [=relevant global object=] of |document|.
-                * |record|'s [=prefetch record/redirect chain=] does not [=redirect chain/has updated credentials|have updated credentials=].
-                * |cutoffTime| is null or |record|'s [=prefetch record/creation time=] is less than |cutoffTime|.
+                * |cutoffTime| is null or |record|'s [=prefetch record/start time=] is less than |cutoffTime|.
         1. If |potentialRecords| [=list/is empty=], return null.
         1. Wait until the [=prefetch record/state=] of any element of |document|'s [=Document/prefetch records=] changes.
         1. If |cutoffTime| is null and any element of |potentialRecords| has a [=prefetch record/state=] that is not "`ongoing`", set |cutoffTime| to the [=current high resolution time=] for the [=relevant global object=] of |document|.
@@ -479,7 +478,7 @@ Update all creation sites to supply an empty string, except for any in this docu
 
             1. Let |request| be the result of [=creating a navigation request=] given <var ignore>entry</var>, <var ignore>sourceSnapshotParams</var>'s [=source snapshot params/fetch client=], <var ignore>navigable</var>'s [=navigable/container=], and <var ignore>sourceSnapshotParams</var>'s [=source snapshot params/has transient activation=].
             1. Set |request|'s [=request/replaces client id=] to <var ignore>navigable</var>'s [=navigable/active document=]'s [=relevant settings object=]'s [=environment/id=].
-            1. Let |prefetchRecord| be the result of [=finding a matching prefetch record=] given <var ignore>navigable</var>'s [=navigable/active document=], <var ignore>entry</var>'s [=session history entry/URL=], and <var ignore>targetSnapshotParams</var>'s [=target snapshot params/sandboxing flags=].
+            1. Let |prefetchRecord| be the result of [=waiting for a matching prefetch record=] given <var ignore>navigable</var>'s [=navigable/active document=], <var ignore>entry</var>'s [=session history entry/URL=], and <var ignore>targetSnapshotParams</var>'s [=target snapshot params/sandboxing flags=].
             1. If <var ignore>documentResource</var> is null and |prefetchRecord| is not null:
                 1. Set <var ignore>navigationParams</var> to the result of [=creating navigation params from a prefetch record=] given <var ignore>navigable</var>, <var ignore>entry</var>'s [=session history entry/document state=], <var ignore>navigationId</var>, <var ignore>navTimingType</var>, <var ignore>request</var>, |prefetchRecord|, <var ignore>targetSnapshotParams</var>, and <var ignore>sourceSnapshotParams</var>.
                 1. [=Copy prefetch cookies=] given |prefetchRecord|'s [=prefetch record/isolated partition key=] and <var ignore>navigationParams</var>'s [=navigation params/reserved environment=].
@@ -670,7 +669,7 @@ The <dfn>list of sufficiently strict speculative navigation referrer policies</d
     1. Set |prefetchRecord|'s [=prefetch record/source partition key=] to the result of [=determining the network partition key=] given |document|'s [=relevant settings object=].
     1. [=Assert=]: |prefetchRecord|'s [=prefetch record/URL=]'s [=url/scheme=] is an [=HTTP(S) scheme=].
     1. [=list/Append=] |prefetchRecord| to |document|'s [=Document/prefetch records=]
-    1. Set |prefetchRecord|'s [=prefetch record/creation time=] to the [=current high resolution time=] for the [=relevant global object=] of |document|.
+    1. Set |prefetchRecord|'s [=prefetch record/start time=] to the [=current high resolution time=] for the [=relevant global object=] of |document|.
     1. Set |prefetchRecord|'s [=prefetch record/sandboxing flag set=] to the result of [=determining the creation sandboxing flags=] for |document|'s [=Document/browsing context=] given |document|'s [=node navigable=]'s [=navigable/container=].
     1. Let |referrerPolicy| be |prefetchRecord|'s [=prefetch record/referrer policy=] if |prefetchRecord|'s [=prefetch record/referrer policy=] is not the empty string, and |document|'s [=Document/policy container=]'s [=policy container/referrer policy=] otherwise.
     1. Let |documentState| be a new [=document state=] with

--- a/prefetch.bs
+++ b/prefetch.bs
@@ -306,7 +306,7 @@ The user agent may [=prefetch record/cancel and discard=] records from the [=Doc
         1. Wait until the [=prefetch record/state=] of any element of |document|'s [=Document/prefetch records=] changes.
         1. If |cutoffTime| is null and any element of |potentialRecords| has a [=prefetch record/state=] that is not "`ongoing`", set |cutoffTime| to the [=current high resolution time=] for the [=relevant global object=] of |document|.
 
-    <p class="note">We have a cutoff for waiting for potential matches such that an additional prefetch that started while we were blocking a navigation could still be used to serve the navigation. In the case of prefetch failure while blocking, we stop considering subsequent prefetches, so we establish a limit after which we fall back to a non-prefetch request.</p>
+    <p class="note">The reasoning for setting the cutoff time *after* waiting for a prefetch record to finish is to allow for flexibility in selecting a prefetch to serve the navigation while still guaranteeing falling back to a non-prefetched navigation in the case of repeated prefetch failures. We allow blocking on prefetch attempts which started before we see an attempt fail, but we don't block on subsequent attempts. Notably, this approach: does not finalize the set of prefetches to block on at the start of the navigation; allows a prefetch which started and completed after the navigation started to serve the navigation; avoids the use of a fixed timeout, which would be arbitrary and detrimental to the use of prefetch with slower servers; and blocks on, at most, two nearly-consecutive prefetches before falling back to a conventional navigation.</p>
 </div>
 
 <div algorithm>

--- a/prefetch.bs
+++ b/prefetch.bs
@@ -122,6 +122,11 @@ spec: nav-speculation; urlPrefix: prerendering.html
   type: dfn
     text: getting the supported loading modes; url: get-the-supported-loading-modes
     text: uncredentialed-prefetch; for: Supports-Loading-Mode; url: supports-loading-mode-uncredentialed-prefetch
+spec: nav-speculation; urlPrefix: no-vary-search.html
+  type: dfn
+    text: URL search variance; url: url-search-variance
+    text: obtain a URL search variance; url: obtain-a-url-search-variance
+    text: equivalent modulo search variance; url: equivalent-modulo-search-variance
 spec: resource-timing; urlPrefix: https://w3c.github.io/resource-timing/
   type: dfn; for: PerformanceResourceTiming; text: delivery type; url: dfn-delivery-type
 </pre>
@@ -185,6 +190,7 @@ A <dfn export>prefetch record</dfn> is a [=struct=] with the following [=struct/
 * <dfn export for="prefetch record">URL</dfn>, a [=URL=]
 * <dfn export for="prefetch record">anonymization policy</dfn>, a [=prefetch IP anonymization policy=]
 * <dfn export for="prefetch record">referrer policy</dfn>, a [=referrer policy=]
+* <dfn export for="prefetch record">No-Vary-Search hint</dfn>, a [=URL search variance=]
 * <dfn export for="prefetch record">label</dfn>, a [=string=]
 
   <div class="note">This is intended for use by a specification or [=implementation-defined=] feature to identify which prefetches it created. It might also associate other data with this struct.</div>
@@ -208,6 +214,24 @@ A [=prefetch record=]'s <dfn export for="prefetch record">response</dfn> is the 
 The user agent may [=prefetch record/cancel and discard=] records from the [=Document/prefetch records=] even if they are not expired, e.g., due to resource constraints. Since completed records with expiry times in the past will never be [=find a matching prefetch record|matching prefetch records=], they can be removed with no observable consequences.
 
 <div algorithm>
+    A [=prefetch record=] |prefetchRecord| <dfn export for="prefetch record">matches a URL</dfn> given a [=URL=] |url| if the following algorithm returns true:
+    1. If |prefetchRecord|'s [=prefetch record/URL=] is equal to |url|, return true.
+    1. If |prefetchRecord|'s [=prefetch record/response=] is not null:
+      1. Let |searchVariance| be the result of [=obtaining a URL search variance=] given |prefetchRecord|'s [=prefetch record/response=].
+      1. If |prefetchRecord|'s [=prefetch record/URL=] and |url| are [=equivalent modulo search variance=] given |searchVariance|, return true.
+    1. Otherwise, return false.
+</div>
+
+<div algorithm>
+    A [=prefetch record=] |prefetchRecord| <dfn export for="prefetch record">possibly matches a URL</dfn> given a [=URL=] |url| if the following algorithm returns true:
+    1. If |prefetchRecord| [=prefetch record/matches a URL=] given |url|, return true.
+    1. If |prefetchRecord|'s [=prefetch record/response=] is null:
+      1. Let |searchVariance| be |prefetchRecord|'s [=prefetch record/No-Vary-Search hint=].
+      1. If |prefetchRecord|'s [=prefetch record/URL=] and |url| are [=equivalent modulo search variance=] given |searchVariance|, return true.
+    1. Otherwise, return false.
+</div>
+
+<div algorithm>
     To <dfn export for="prefetch record">cancel and discard</dfn> a [=prefetch record=] |prefetchRecord| given a {{Document}} |document|, perform the following steps.
 
     1. [=Assert=]: |prefetchRecord| is in |document|'s [=Document/prefetch records=].
@@ -225,12 +249,13 @@ The user agent may [=prefetch record/cancel and discard=] records from the [=Doc
     1. [=Assert=]: |document| is [=Document/fully active=].
     1. Let |currentTime| be the [=current high resolution time=] for the [=relevant global object=] of |document|.
     1. Let |expiryTime| be |currentTime| + 300000 (i.e., five minutes).
-    1. [=list/Remove=] all elements of |document|'s [=Document/prefetch records=] which have the same [=prefetch record/URL=] as |prefetchRecord| and whose [=prefetch record/state=] equals "`completed`".
+    1. [=list/Remove=] all elements of |document|'s [=Document/prefetch records=] which [=prefetch record/match a URL=] given |prefetchRecord|'s [=prefetch record/URL=] and whose [=prefetch record/state=] equals "`completed`".
     1. Set |prefetchRecord|'s [=prefetch record/state=] to "`completed`" and [=prefetch record/expiry time=] to |expiryTime|.
 </div>
 
 <div algorithm="find a matching prefetch record">
     To <dfn export>find a matching prefetch record</dfn> given a {{Document}} |document|, [=URL=] |url|, and [=sandboxing flag set=] |sandboxFlags|, perform the following steps.
+    TODO from here
 
     1. [=Assert=]: |document| is [=Document/fully active=].
     1. Let |currentTime| be the [=current high resolution time=] for the [=relevant global object=] of |document|.

--- a/prefetch.bs
+++ b/prefetch.bs
@@ -290,15 +290,24 @@ The user agent may [=prefetch record/cancel and discard=] records from the [=Doc
     To <dfn export>find a matching prefetch record</dfn> given a {{Document}} |document|, [=URL=] |url|, and [=sandboxing flag set=] |sandboxFlags|, perform the following steps.
 
     1. [=Assert=]: this is running [=in parallel=].
-    1. Let |cutoff| be null.
+    1. Let |cutoffTime| be null.
     1. While true:
         1. Let |completeRecord| be the result of [=finding a matching complete prefetch record=] given |document|, |url|, and |sandboxFlags|.
         1. If |completeRecord| is not null, return |completeRecord|.
-        1. Let |potentialRecords| be an empty [=list=]. TODO
+        1. Let |potentialRecords| be an empty [=list=].
         1. [=list/For each=] |record| of |document|'s [=Document/prefetch records=]:
-            1. If |record|'s [=prefetch record/state=] is "`ongoing`" and |record| [=prefetch record/possibly matches a URL=] given |url|:
-        1. If |mayBecomeServable| is false, return null.
-        1. Await TODO
+            1. If all of the following are true, then [=list/append=] |record| to |potentialRecords|:
+                * |record|'s [=prefetch record/state=] is "`ongoing`".
+                * |record| [=prefetch record/possibly matches a URL=] given |url|.
+                * |record|'s [=prefetch record/sandboxing flag set=] is not empty or |sandboxFlags| is empty.
+                * |record|'s [=prefetch record/expiry time=] is greater than the [=current high resolution time=] for the [=relevant global object=] of |document|.
+                * |record|'s [=prefetch record/redirect chain=] does not [=redirect chain/has updated credentials|have updated credentials=].
+                * |cutoffTime| is null or |record|'s [=prefetch record/creation time=] is less than |cutoffTime|.
+        1. If |potentialRecords| [=list/is empty=], return null.
+        1. Wait until the [=prefetch record/state=] of any element of |document|'s [=Document/prefetch records=] changes.
+        1. If |cutoffTime| is null and any element of |potentialRecords| has a [=prefetch record/state=] that is not "`ongoing`", set |cutoffTime| to the [=current high resolution time=] for the [=relevant global object=] of |document|.
+
+    <p class="note">We have a cutoff for waiting for potential matches such that an additional prefetch that started while we were blocking a navigation could still be used to serve the navigation. In the case of prefetch failure while blocking, we stop considering subsequent prefetches, so we establish a limit after which we fall back to a non-prefetch request.</p>
 </div>
 
 <div algorithm>

--- a/prefetch.bs
+++ b/prefetch.bs
@@ -200,6 +200,7 @@ A <dfn export>prefetch record</dfn> is a [=struct=] with the following [=struct/
 * <dfn export for="prefetch record">fetch controller</dfn>, a [=fetch controller=] (a new [=fetch controller=] by default)
 * <dfn export for="prefetch record">sandboxing flag set</dfn>, a [=sandboxing flag set=]
 * <dfn export for="prefetch record">redirect chain</dfn>, a [=redirect chain=] (empty by default)
+* <dfn export for="prefetch record">creation time</dfn>, a {{DOMHighResTimeStamp}} (0.0 by default)
 * <dfn export for="prefetch record">expiry time</dfn>, a {{DOMHighResTimeStamp}} (0.0 by default)
 * <dfn export for="prefetch record">source partition key</dfn>, a [=network partition key=] or null (the default)
 * <dfn export for="prefetch record">isolated partition key</dfn>, a [=network partition key=] whose first item is an [=opaque origin=] and which represents a separate partition in which cross-partition state can be temporarily stored, or null (the default)
@@ -253,29 +254,51 @@ The user agent may [=prefetch record/cancel and discard=] records from the [=Doc
     1. Set |prefetchRecord|'s [=prefetch record/state=] to "`completed`" and [=prefetch record/expiry time=] to |expiryTime|.
 </div>
 
-<div algorithm="find a matching prefetch record">
-    To <dfn export>find a matching prefetch record</dfn> given a {{Document}} |document|, [=URL=] |url|, and [=sandboxing flag set=] |sandboxFlags|, perform the following steps.
-    TODO from here
+<div algorithm="find a matching complete prefetch record">
+    To <dfn export>find a matching complete prefetch record</dfn> given a {{Document}} |document|, [=URL=] |url|, and [=sandboxing flag set=] |sandboxFlags|, perform the following steps.
 
     1. [=Assert=]: |document| is [=Document/fully active=].
-    1. Let |currentTime| be the [=current high resolution time=] for the [=relevant global object=] of |document|.
+    1. Let |exactRecord| be null.
+    1. Let |inexactRecord| be null.
     1. [=list/For each=] |record| of |document|'s [=Document/prefetch records=]:
-        1. If |record|'s [=prefetch record/URL=] is not equal to |url|, then [=iteration/continue=].
         1. If |record|'s [=prefetch record/state=] is not "`completed`", then [=iteration/continue=].
         1. If |record|'s [=prefetch record/sandboxing flag set=] is empty and |sandboxFlags| is not empty, then [=iteration/continue=].
 
             <div class="note">
               Strictly speaking, it would still be possible for this to be valid if sandbox flags have been added to the container since prefetch but those flags would not cause an error due to cross origin opener policy. This is expected to be rare and so isn't handled.
             </div>
-        1. [=list/Remove=] |record| from |document|'s [=Document/prefetch records=].
-        1. If |record|'s [=prefetch record/expiry time=] is less than |currentTime|, return null.
-        1. If |record|'s [=prefetch record/redirect chain=] [=redirect chain/has updated credentials=], return null.
-        1. Return |record|.
+        1. If |record|'s [=prefetch record/URL=] is equal to |url|:
+            1. Set |exactRecord| to |record|.
+            1. [=iteration/Break=].
+        1. If |inexactRecord| is null and |record| [=prefetch record/matches a URL=] given |url|:
+            1. Set |inexactRecord| to |record|.
+    1. Let |recordToUse| be |exactRecord| if |exactRecord| is not null, otherwise |inexactRecord|.
+    1. If |recordToUse| is not null:
+        1. [=list/Remove=] |recordToUse| from |document|'s [=Document/prefetch records=].
+        1. Let |currentTime| be the [=current high resolution time=] for the [=relevant global object=] of |document|.
+        1. If |recordToUse|'s [=prefetch record/expiry time=] is less than |currentTime|, return null.
+        1. If |recordToUse|'s [=prefetch record/redirect chain=] [=redirect chain/has updated credentials=], return null.
+        1. Return |recordToUse|.
     1. Return null.
 
     <p class="note">It's not obvious, but this doesn't actually require that the prefetch have received the complete body, just the response headers. In particular, a navigation to a prefetched response might nonetheless not load instantaneously.</p>
 
     <p class="issue">It might be possible to use cache response headers to determine when a response can be used multiple times, but given the short lifetime of the prefetch buffer it's unclear whether this is worthwhile.</p>
+</div>
+
+<div algorithm="find a matching prefetch record">
+    To <dfn export>find a matching prefetch record</dfn> given a {{Document}} |document|, [=URL=] |url|, and [=sandboxing flag set=] |sandboxFlags|, perform the following steps.
+
+    1. [=Assert=]: this is running [=in parallel=].
+    1. Let |cutoff| be null.
+    1. While true:
+        1. Let |completeRecord| be the result of [=finding a matching complete prefetch record=] given |document|, |url|, and |sandboxFlags|.
+        1. If |completeRecord| is not null, return |completeRecord|.
+        1. Let |potentialRecords| be an empty [=list=]. TODO
+        1. [=list/For each=] |record| of |document|'s [=Document/prefetch records=]:
+            1. If |record|'s [=prefetch record/state=] is "`ongoing`" and |record| [=prefetch record/possibly matches a URL=] given |url|:
+        1. If |mayBecomeServable| is false, return null.
+        1. Await TODO
 </div>
 
 <div algorithm>
@@ -638,6 +661,7 @@ The <dfn>list of sufficiently strict speculative navigation referrer policies</d
     1. Set |prefetchRecord|'s [=prefetch record/source partition key=] to the result of [=determining the network partition key=] given |document|'s [=relevant settings object=].
     1. [=Assert=]: |prefetchRecord|'s [=prefetch record/URL=]'s [=url/scheme=] is an [=HTTP(S) scheme=].
     1. [=list/Append=] |prefetchRecord| to |document|'s [=Document/prefetch records=]
+    1. Set |prefetchRecord|'s [=prefetch record/creation time=] to the [=current high resolution time=] for the [=relevant global object=] of |document|.
     1. Set |prefetchRecord|'s [=prefetch record/sandboxing flag set=] to the result of [=determining the creation sandboxing flags=] for |document|'s [=Document/browsing context=] given |document|'s [=node navigable=]'s [=navigable/container=].
     1. Let |referrerPolicy| be |prefetchRecord|'s [=prefetch record/referrer policy=] if |prefetchRecord|'s [=prefetch record/referrer policy=] is not the empty string, and |document|'s [=Document/policy container=]'s [=policy container/referrer policy=] otherwise.
     1. Let |documentState| be a new [=document state=] with

--- a/speculation-rules.bs
+++ b/speculation-rules.bs
@@ -75,6 +75,7 @@ spec: nav-speculation; urlPrefix: prefetch.html
       text: label; url: prefetch-record-label
       text: state; url: prefetch-record-state
       text: cancel and discard; url: prefetch-record-cancel-and-discard
+      text: matches a URL; url: prefetch-record-matches-a-url
     text: prefetch IP anonymization policy; url: prefetch-ip-anonymization-policy
     text: cross-origin prefetch IP anonymization policy; url: cross-origin-prefetch-ip-anonymization-policy
     text: origin; for: cross-origin prefetch IP anonymization policy; url: cross-origin-prefetch-ip-anonymization-policy-origin
@@ -531,10 +532,9 @@ A <dfn>prerender candidate</dfn> is a [=struct=] with the following [=struct/ite
   A [=prefetch candidate=] |prefetchCandidate| <dfn for="prefetch candidate">continues</dfn> a [=prefetch record=] |prefetchRecord| if the following are all true:
   * |prefetchRecord|'s [=prefetch record/label=] is "`speculation-rules`"
   * |prefetchRecord|'s [=prefetch record/state=] is not "`canceled`"
-  * |prefetchRecord|'s [=prefetch record/URL=] equals |prefetchCandidate|'s [=prefetch candidate/URL=]
+  * |prefetchRecord| [=prefetch record/matches a URL=] given |prefetchCandidate|'s [=prefetch candidate/URL=]
   * |prefetchRecord|'s [=prefetch record/anonymization policy=] equals |prefetchCandidate|'s [=prefetch candidate/anonymization policy=]
 
-  TODO
 </div>
 
 <div algorithm>

--- a/speculation-rules.bs
+++ b/speculation-rules.bs
@@ -414,9 +414,7 @@ add the following step
   1. Let |noVarySearchHint| be the [=default URL search variance=].
   1. If |input|["`expects_no_vary_search`"] [=map/exists=]:
     1. If |input|["`expects_no_vary_search`"] is not a [=string=], then return null.
-    1. Let |hint| be the result of [=obtaining a URL search variance hint=] given |input|["`expects_no_vary_search`"].
-    1. If |hint| is null, then return null.
-    1. Set |noVarySearchHint| to |hint|.
+    1. Set |noVarySearchHint| to the result of [=obtaining a URL search variance hint=] given |input|["`expects_no_vary_search`"].
   1. Return a [=speculation rule=] with
     :  [=speculation rule/URLs=]
     :: |urls|

--- a/speculation-rules.bs
+++ b/speculation-rules.bs
@@ -89,6 +89,7 @@ spec: nav-speculation; urlPrefix: no-vary-search.html
     text: URL search variance; url: url-search-variance
     text: default URL search variance; url: default-url-search-variance
     text: obtain a URL search variance hint; url: obtain-a-url-search-variance-hint
+    text: equivalent modulo search variance; url: equivalent-modulo-search-variance
 </pre>
 <style>
 /* domintro from https://resources.whatwg.org/standard.css */
@@ -618,6 +619,8 @@ A <dfn>prerender candidate</dfn> is a [=struct=] with the following [=struct/ite
   :: User agents should enact the candidate if user behavior suggests the user may navigate to this URL in the near future. For instance, the user might have scrolled a link into the viewport and moved the cursor over or near it.
   :  "`conservative`"
   :: User agents should enact the candidate only when the user is very likely to navigate to this URL at any moment. For instance, the user might have begun to interact with a link.
+
+  <p class="note">A user agent's heuristics for enacting non-eager candidates could incorporate a [=prefetch candidate/No-Vary-Search hint=]. For example, a user hovering over a link whose URL and a candidate's [=prefetch candidate/URL=] are [=equivalent modulo search variance=] given the candidate's [=prefetch candidate/No-Vary-Search hint=] could indicate to the user agent that enacting it would be useful.</p>
 
   Notwithstanding the above, user agents should prioritize user preferences (express and implied, such as a low-data-usage mode) over eagerness expressed by the author.
 </div>

--- a/speculation-rules.bs
+++ b/speculation-rules.bs
@@ -71,6 +71,7 @@ spec: nav-speculation; urlPrefix: prefetch.html
       text: URL; url: prefetch-record-url
       text: anonymization policy; url: prefetch-record-anonymization-policy
       text: referrer policy; url: prefetch-record-referrer-policy
+      text: No-Vary-Search hint; url: prefetch-record-no-vary-search-hint
       text: label; url: prefetch-record-label
       text: state; url: prefetch-record-state
       text: cancel and discard; url: prefetch-record-cancel-and-discard
@@ -82,6 +83,11 @@ spec: nav-speculation; urlPrefix: prerendering.html
     text: start referrer-initiated prerendering; url: start-referrer-initiated-prerendering
     text: prerendering traversable; url: prerendering-traversable
     text: activate; for: prerendering traversable; url: prerendering-traversable-activate
+spec: nav-speculation; urlPrefix: no-vary-search.html
+  type: dfn
+    text: URL search variance; url: url-search-variance
+    text: default URL search variance; url: default-url-search-variance
+    text: obtain a URL search variance hint; url: obtain-a-url-search-variance-hint
 </pre>
 <style>
 /* domintro from https://resources.whatwg.org/standard.css */
@@ -126,6 +132,7 @@ A <dfn>speculation rule</dfn> is a [=struct=] with the following [=struct/items=
 * <dfn for="speculation rule">target navigable name hint</dfn>, a [=string=] or null
 * <dfn for="speculation rule">referrer policy</dfn>, a [=referrer policy=]
 * <dfn for="speculation rule">eagerness</dfn>, one of the [=valid eagerness strings=]
+* <dfn for="speculation rule">No-Vary-Search hint</dfn>, a [=URL search variance=]
 
 The only valid string for [=speculation rule/requirements=] to contain is "`anonymous-client-ip-when-cross-origin`".
 
@@ -361,7 +368,7 @@ add the following step
 <div algorithm="parse a speculation rule">
   To <dfn>parse a speculation rule</dfn> given a [=map=] |input|, a [=document=] |document|, and a [=URL=] |baseURL|, perform the following steps. They return a [=speculation rule=] or null.
 
-  1. If |input| has any [=map/key=] other than "`source`", "`urls`", "`where`", "`requires`", "`target_hint`","`referrer_policy`", "`relative_to`", and "`eagerness`" then return null.
+  1. If |input| has any [=map/key=] other than "`source`", "`urls`", "`where`", "`requires`", "`target_hint`","`referrer_policy`", "`relative_to`", "`eagerness`", and "`expects_no_vary_search`" then return null.
   1. If |input|["`source`"] does not [=map/exist=] or is neither the [=string=] "`list`" nor the [=string=] "`document`", then return null.
   1. Let |source| be |input|["`source`"].
   1. Let |urls| be an empty [=list=].
@@ -403,6 +410,12 @@ add the following step
   1. If |input|["`eagerness`"] [=map/exists=]:
     1. If |input|["`eagerness`"] is not one of the [=valid eagerness strings=], then return null.
     1. Set |eagerness| to |input|["`eagerness`"].
+  1. Let |noVarySearchHint| be the [=default URL search variance=].
+  1. If |input|["`expects_no_vary_search`"] [=map/exists=]:
+    1. If |input|["`expects_no_vary_search`"] is not a [=string=], then return null.
+    1. Let |hint| be the result of [=obtaining a URL search variance hint=] given |input|["`expects_no_vary_search`"].
+    1. If |hint| is null, then return null.
+    1. Set |noVarySearchHint| to |hint|.
   1. Return a [=speculation rule=] with
     :  [=speculation rule/URLs=]
     :: |urls|
@@ -416,6 +429,8 @@ add the following step
     :: |referrerPolicy|
     :  [=speculation rule/eagerness=]
     :: |eagerness|
+    :  [=speculation rule/No-Vary-Search hint=]
+    :: |noVarySearchHint|
 </div>
 
 <div algorithm="parse a document rule predicate">
@@ -504,6 +519,7 @@ A <dfn>prefetch candidate</dfn> is a [=struct=] with the following [=struct/item
 * <dfn for="prefetch candidate">anonymization policy</dfn>, a [=prefetch IP anonymization policy=]
 * <dfn for="prefetch candidate">referrer policy</dfn>, a [=referrer policy=]
 * <dfn for="prefetch candidate">eagerness</dfn>, one of the [=valid eagerness strings=]
+* <dfn for="prefetch candidate">No-Vary-Search hint</dfn>, a [=URL search variance=]
 
 A <dfn>prerender candidate</dfn> is a [=struct=] with the following [=struct/items=]:
 * <dfn for="prerender candidate">URL</dfn>, a [=URL=]
@@ -517,6 +533,8 @@ A <dfn>prerender candidate</dfn> is a [=struct=] with the following [=struct/ite
   * |prefetchRecord|'s [=prefetch record/state=] is not "`canceled`"
   * |prefetchRecord|'s [=prefetch record/URL=] equals |prefetchCandidate|'s [=prefetch candidate/URL=]
   * |prefetchRecord|'s [=prefetch record/anonymization policy=] equals |prefetchCandidate|'s [=prefetch candidate/anonymization policy=]
+
+  TODO
 </div>
 
 <div algorithm>
@@ -558,13 +576,13 @@ A <dfn>prerender candidate</dfn> is a [=struct=] with the following [=struct/ite
       1. &#x231B; If |rule|'s [=speculation rule/requirements=] [=set/contains=] "`anonymous-client-ip-when-cross-origin`", set |anonymizationPolicy| to a [=cross-origin prefetch IP anonymization policy=] whose [=cross-origin prefetch IP anonymization policy/origin=] is |document|'s [=Document/origin=].
       1. &#x231B; [=list/For each=] |url| of |rule|'s [=speculation rule/URLs=]:
         1. &#x231B; Let |referrerPolicy| be the result of [=computing a speculative action referrer policy=] given |rule| and null.
-        1. &#x231B; [=list/Append=] a [=prefetch candidate=] with [=prefetch candidate/URL=] |url|, [=prefetch candidate/anonymization policy=] |anonymizationPolicy|, [=prefetch candidate/referrer policy=] |referrerPolicy|, and [=prefetch candidate/eagerness=] |rule|'s [=speculation rule/eagerness=] to |prefetchCandidates|.
+        1. &#x231B; [=list/Append=] a [=prefetch candidate=] with [=prefetch candidate/URL=] |url|, [=prefetch candidate/anonymization policy=] |anonymizationPolicy|, [=prefetch candidate/referrer policy=] |referrerPolicy|, [=prefetch candidate/eagerness=] |rule|'s [=speculation rule/eagerness=], and [=prefetch candidate/No-Vary-Search hint=] |rule|'s [=speculation rule/No-Vary-Search hint=] to |prefetchCandidates|.
       1. &#x231B; If |rule|'s [=speculation rule/predicate=] is not null, then:
         1. &#x231B; Let |links| be the result of [=finding matching links=] given |document| and |rule|'s [=speculation rule/predicate=].
         1. &#x231B; [=list/For each=] |link| of |links|:
           1. &#x231B; Let |url| be |link|'s [=HTMLHyperlinkElementUtils/url=].
           1. &#x231B; Let |referrerPolicy| be the result of [=computing a speculative action referrer policy=] given |rule| and |link|.
-          1. &#x231B; [=list/Append=] a [=prefetch candidate=] with [=prefetch candidate/URL=] |url|, [=prefetch candidate/anonymization policy=] |anonymizationPolicy|, and [=prefetch candidate/referrer policy=] |referrerPolicy| to |prefetchCandidates|.
+          1. &#x231B; [=list/Append=] a [=prefetch candidate=] with [=prefetch candidate/URL=] |url|, [=prefetch candidate/anonymization policy=] |anonymizationPolicy|, [=prefetch candidate/referrer policy=] |referrerPolicy|, and [=prefetch candidate/No-Vary-Search hint=] |rule|'s [=speculation rule/No-Vary-Search hint=] to |prefetchCandidates|.
     1. &#x231B; [=list/For each=] |rule| of |ruleSet|'s [=speculation rule set/prerender rules=]:
       1. &#x231B; [=list/For each=] |url| of |rule|'s [=speculation rule/URLs=]:
         1. &#x231B; Let |referrerPolicy| be the result of [=computing a speculative action referrer policy=] given |rule| and null.
@@ -586,7 +604,7 @@ A <dfn>prerender candidate</dfn> is a [=struct=] with the following [=struct/ite
   1. End the [=synchronous section=], continuing the remaining steps [=in parallel=].
   1. [=list/For each=] |prefetchCandidate| of |prefetchCandidates|:
     1. The user agent may run the following steps:
-      1. Let |prefetchRecord| be a new [=prefetch record=] whose [=prefetch record/URL=] is |prefetchCandidate|'s [=prefetch candidate/URL=], [=prefetch record/anonymization policy=] is |prefetchCandidate|'s [=prefetch candidate/anonymization policy=], [=prefetch record/referrer policy=] is |prefetchCandidate|'s [=prefetch candidate/referrer policy=], and [=prefetch record/label=] is "`speculation-rules`".
+      1. Let |prefetchRecord| be a new [=prefetch record=] whose [=prefetch record/URL=] is |prefetchCandidate|'s [=prefetch candidate/URL=], [=prefetch record/anonymization policy=] is |prefetchCandidate|'s [=prefetch candidate/anonymization policy=], [=prefetch record/referrer policy=] is |prefetchCandidate|'s [=prefetch candidate/referrer policy=], [=prefetch record/No-Vary-Search hint=] is |prefetchCandidate|'s [=prefetch candidate/No-Vary-Search hint=], and [=prefetch record/label=] is "`speculation-rules`".
       1. [=Prefetch=] given |document| and |prefetchRecord|.
   1. [=list/For each=] |prerenderCandidate| of |prerenderCandidates|:
       1. The user agent may [=start referrer-initiated prerendering=] given |prerenderCandidate|'s [=prerender candidate/URL=], |document|, and |prerenderCandidate|'s [=prerender candidate/referrer policy=].


### PR DESCRIPTION
We introduce the "expects_no_vary_search" field for speculation rules and specify how it is parsed.

When matching prefetch records, we now have it:
* perform inexact matches based on the response's No-Vary-Search value
* block on the availability of headers for potential matches
* have the identification of potential matches incorporate the No-Vary-Search hint

Note that this spec text describes blocking on any available prefetch. The current chromium implementation blocks only on a single ongoing prefetch.