### PR TITLE
Document rules: skip links which are not being rendered or in skipped contents

### DIFF
--- a/speculation-rules.bs
+++ b/speculation-rules.bs
@@ -545,6 +545,9 @@ A <dfn>prerender candidate</dfn> is a [=struct=] with the following [=struct/ite
 
         <div class="note">This corresponds to the elements which match '':any-link'' [=pseudo-class=], or which appear in the {{Document/links}} collection.</div>
 
+    1. If |descendant| is not [=being rendered=] or is part of [=skipped contents=], [=iteration/continue=].
+
+        <div class="note">Such links, though present in the document, aren't available for the user to interact with and are unlikely to be good candidates. In addition, they may not have their style or layout computed, which might make CSS selector matching less efficient in user agents which skip some or all of that work for these elements.</div>
     1. Let |url| be |descendant|'s [=HTMLHyperlinkElementUtils/url=].
     1. If |url| is null, or its [=url/scheme=] is not an [=HTTP(S) scheme=], [=iteration/continue=].
     1. If |predicate| [=document rule predicate/matches=] |descendant|, then [=list/append=] |descendant| to |links|.


### PR DESCRIPTION
It's hard for the user to interact with these links, and the author may not even intend them to be part of the document's palpable content.

In at least Chromium (and likely other implementations), these are also elements where the author is trying to skip work related to selector matching etc, which makes selector_matches applying to them particularly problematic. Better to ignore them altogether.

Fixes #246.