### PR TITLE
Editorial: Fix link to URL Pattern match algorithm

### DIFF
--- a/speculation-rules.bs
+++ b/speculation-rules.bs
@@ -653,7 +653,7 @@ A <dfn>prerender candidate</dfn> is a [=struct=] with the following [=struct/ite
   1. If |predicate| is a [=document rule URL pattern predicate=], then:
     1. Let |href| be the result of running |el|'s {{HTMLHyperlinkElementUtils/href}} getter steps.
     1. [=list/For each=] |pattern| of |predicate|'s [=document rule URL pattern predicate/patterns=]:
-      1. <a spec="urlpattern">Match</a> given |pattern| and |href|. If the result is not null, return true.
+      1. [=URLPattern/Match=] given |pattern| and |href|. If the result is not null, return true.
     1. Return false.
   1. If |predicate| is a [=document rule CSS selector predicate=], then:
     1. [=list/For each=] |selector| of |predicate|'s [=document rule CSS selector predicate/selectors=]:


### PR DESCRIPTION
This was changed upstream in whatwg/urlpattern@531a2ccf.

Fixes #292.