### PR TITLE
Spec the use of No-Vary-Search with prerender

### DIFF
--- a/prerendering.bs
+++ b/prerendering.bs
@@ -267,15 +267,21 @@ Every {{Document}} has an <dfn for="Document">activation start time</dfn>, which
 
      <p class="note">We treat this initial navigations as |prerenderingTraversable| navigating itself, which will ensure all relevant security checks pass.
 
-  1. When the user indicates they wish to commit the navigation and create a new user-visible [=top-level traversable=] while doing so (e.g., by pressing <kbd><kbd>Shift</kbd>+<kbd>Enter</kbd></kbd> after typing in the address bar):
+  1. Let |record| be a [=prerender record=] with [=prerender record/starting URL=] |startingURL| and [=prerender record/prerendering traversable=] |prerenderingTraversable|.
 
-    1. Update the user agent's user interface to present |prerenderingTraversable|, e.g., by creating a new tab/window.
+  1. When the user indicates they wish to commit a navigation to an |activationUrl| which is a [=URL=] such that |record| [=prerender record/matches a URL=] given |activationUrl|:
 
-    1. [=prerendering traversable/Finalize activation=] for |prerenderingTraversable| given |startingURL|'s [=url/origin=].
+    1. If the user indicates they wish to create a new user-visible [=top-level traversable=] while doing so (e.g., by pressing <kbd><kbd>Shift</kbd>+<kbd>Enter</kbd></kbd> after typing in the address bar):
 
-  1. Alternately, when they use indicates they wish to commit the navigation into an existing [=top-level traversable=] |predecessorTraversable| (e.g., by pressing <kbd>Enter</kbd> after typing in the address bar):
+      1. TODO update URL
 
-    1. [=prerendering traversable/Activate=] |prerenderingTraversable| in place of |predecessorTraversable| given "`push`".
+      1. Update the user agent's user interface to present |prerenderingTraversable|, e.g., by creating a new tab/window.
+
+      1. [=prerendering traversable/Finalize activation=] for |prerenderingTraversable| given |startingURL|'s [=url/origin=].
+
+    1. Alternately, if the user indicates they wish to commit the navigation into an existing [=top-level traversable=] |predecessorTraversable| (e.g., by pressing <kbd>Enter</kbd> after typing in the address bar):
+
+      1. [=prerendering traversable/Activate=] |prerenderingTraversable| in place of |predecessorTraversable| given "`push`", |startingURL|, and |activationUrl|.
 
   <p class="note">The user might never indicate such a commitment, or might take long enough to do so that the user agent needs to reclaim the resources used by the prerender for some more immediate task. In that case the user agent can [=destroy a top-level traversable|destroy=] |prerenderingTraversable|.
 </div>
@@ -316,7 +322,7 @@ Every {{Document}} has an <dfn for="Document">activation start time</dfn>, which
 </div>
 
 <div algorithm>
-TODO activate call sites
+
   To <dfn for="prerendering traversable">activate</dfn> a [=prerendering traversable=] |successorTraversable| in place of a [=top-level traversable=] |predecessorTraversable| given a [=history handling behavior=] |historyHandling|, a [=URL=] |startingUrl|, a [=URL=] |activationUrl|, an optional [=navigation ID=] |navigationId|:
 
   1. [=Assert=]: |successorTraversable|'s [=navigable/active document=]'s [=Document/is initial about:blank=] is false.
@@ -346,6 +352,7 @@ TODO activate call sites
       1. Let |navigation| be |successorDocument|'s [=relevant global object=]'s [=navigation API=].
 
       1. Let |continue| be the result of [=firing a push-replace-reload navigate event=] at |navigation| given "[=NavigationType/replace=]", |activationUrl|, and true.
+         <p class="issue">Should we do this or just do the update without the event? TODO: resolve before submit
 
       1. If |continue| is true, run the [=URL and history update steps=] given |successorDocument| and |activationUrl|.
 
@@ -441,7 +448,7 @@ TODO activate call sites
 </div>
 
 <div algorithm>
-  To <dfn>wait for a matching prerendering navigable</dfn> given a [=navigable=] |navigable|, a [=URL=] |url|, a string |cspNavigationType|, and a [=POST resource=], string, or null |documentResource|:
+  To <dfn>wait for a matching prerendering record</dfn> given a [=navigable=] |navigable|, a [=URL=] |url|, a string |cspNavigationType|, and a [=POST resource=], string, or null |documentResource|:
 
   1. [=Assert=]: this is running [=in parallel=].
   1. If any of the following conditions hold:
@@ -459,7 +466,7 @@ TODO activate call sites
   1. Let |cutoffTime| be null.
   1. While true:
       1. Let |completeRecord| be the result of [=finding a matching complete prerender record=] given |predecessorDocument| and |url|.
-      1. If |completeRecord| is not null, return |completeRecord|'s [=prerender record/prerendering traversable=].
+      1. If |completeRecord| is not null, return |completeRecord|.
       1. Let |potentialRecords| be an empty [=list=].
       1. [=list/For each=] |record| of |predecessorDocument|'s [=Document/prerender records=]:
           1. If all of the following are true, then [=list/append=] |record| to |potentialRecords|:
@@ -477,11 +484,14 @@ Patch the [=navigate=] algorithm to allow the [=prerendering traversable/activat
 <div algorithm="navigate activate patch">
   In [=navigate=], insert the following steps as the first ones after we go [=in parallel=]:
 
-  1. Let |matchingPrerenderedNavigable| be the result of [=waiting for a matching prerendering navigable=] given |navigable|, <var ignore>url</var>, <var ignore>cspNavigationType</var>, and <var ignore>documentResource</var>.
+  1. Let |matchingPrerenderRecord| be the result of [=waiting for a matching prerendering record=] given |navigable|, <var ignore>url</var>, <var ignore>cspNavigationType</var>, and <var ignore>documentResource</var>.
 
-  1. If |matchingPrerenderedNavigable| is not null, then:
+  1. If |matchingPrerenderRecord| is not null, then:
+      1. Let |matchingPrerenderedNavigable| be |matchingPrerenderRecord|'s [=prerender record/prerendering traversable=].
 
-      1. [=prerendering traversable/Activate=] |matchingPrerenderedNavigable| in place of |navigable| given <var ignore>historyHandling</var> and <var ignore>navigationId</var>.
+      1. Let |startingUrl| be |matchingPrerenderRecord|'s [=prerender record/starting URL=].
+
+      1. [=prerendering traversable/Activate=] |matchingPrerenderedNavigable| in place of |navigable| given <var ignore>historyHandling</var>, |startingUrl|, <var ignore>url</var>, and <var ignore>navigationId</var>.
 
       1. Abort these steps.
 </div>

--- a/prerendering.bs
+++ b/prerendering.bs
@@ -35,7 +35,7 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
     text: current playback position; url: media.html#current-playback-position
     text: destroy a top-level traversable; url: document-sequences.html#destroy-a-top-level-traversable
     text: finalize a cross-document navigation; url: browsing-the-web.html#finalize-a-cross-document-navigation
-    text: fire a push-replace-reload navigate event; url: nav-history-apis.html#fire-a-push/replace/reload-navigate-event
+    text: fire a push/replace/reload navigate event; url: nav-history-apis.html#fire-a-push/replace/reload-navigate-event
     text: hand-off to external software; url: browsing-the-web.html#hand-off-to-external-software
     text: history handling behavior; url: browsing-the-web.html#history-handling-behavior
     text: navigation and traversal task source; url: webappapis.html#navigation-and-traversal-task-source
@@ -203,7 +203,7 @@ By default, a [=navigable=]'s [=navigable/loading mode=] is "`default`". A navig
 
 <p class="note">Although there are only two values for the [=navigable/loading mode=], we use a flexible structure in anticipation of other future loading modes, such as those provided by fenced frames, portals, and uncredentialed (cross-site) prerendering. It's not yet clear whether that anticipation is correct; if, as those features gain full specifications, it turns out not to be, we will instead convert this into a boolean.
 
-Every [=prerendering traversable=] has an <dfn for="prerendering traversable">initial prerender search variance</dfn>, which is a [=URL search variance=] or null, and is initially null.
+Every [=prerendering traversable=] has a <dfn for="prerendering traversable">prerender initial response search variance</dfn>, which is a [=URL search variance=] or null, and is initially null.
 
 <dl class="domintro">
   <dt><code><var ignore>document</var>.{{Document/prerendering}}</code></dt>
@@ -226,19 +226,19 @@ A <dfn export>prerender record</dfn> is a [=struct=] with the following [=struct
 <div algorithm>
     A [=prerender record=] |prerenderRecord| <dfn export for="prerender record">matches a URL</dfn> given a [=URL=] |url| if the following algorithm returns true:
     1. If |prerenderRecord|'s [=prerender record/starting URL=] is equal to |url|, return true.
-    1. Let |searchVariance| be |prerenderRecord|'s [=prerender record/prerendering traversable=]'s [=prerendering traversable/initial prerender search variance=].
+    1. Let |searchVariance| be |prerenderRecord|'s [=prerender record/prerendering traversable=]'s [=prerendering traversable/prerender initial response search variance=].
     1. If |searchVariance| is not null:
       1. If |prerenderRecord|'s [=prerender record/starting URL=] and |url| are [=equivalent modulo search variance=] given |searchVariance|, return true.
-    1. Otherwise, return false.
+    1. Return false.
 </div>
 
 <div algorithm>
     A [=prerender record=] |prerenderRecord| <dfn export for="prerender record">is expected to match a URL</dfn> given a [=URL=] |url| if the following algorithm returns true:
     1. If |prerenderRecord| [=prerender record/matches a URL=] given |url|, return true.
-    1. If |prerenderRecord|'s [=prerender record/prerendering traversable=]'s [=prerendering traversable/initial prerender search variance=] is null:
-      1. Let |searchVariance| be |prerenderRecord|'s [=prerender record/No-Vary-Search hint=].
-      1. If |prerenderRecord|'s [=prerender record/starting URL=] and |url| are [=equivalent modulo search variance=] given |searchVariance|, return true.
-    1. Otherwise, return false.
+    1. If |prerenderRecord|'s [=prerender record/prerendering traversable=]'s [=prerendering traversable/prerender initial response search variance=] is null:
+      1. Let |expectedSearchVariance| be |prerenderRecord|'s [=prerender record/No-Vary-Search hint=].
+      1. If |prerenderRecord|'s [=prerender record/starting URL=] and |url| are [=equivalent modulo search variance=] given |expectedSearchVariance|, return true.
+    1. Return false.
 </div>
 
 Every {{Document}} has a <dfn for="Document">post-prerendering activation steps list</dfn>, which is a [=list=] where each [=list/item=] is a series of algorithm steps. For convenience, we define the <dfn for="platform object">post-prerendering activation steps list</dfn> for any platform object |platformObject| as:
@@ -334,8 +334,7 @@ Every {{Document}} has an <dfn for="Document">activation start time</dfn>, which
 
     1. Let |navigation| be |successorDocument|'s [=relevant global object=]'s [=navigation API=].
 
-    1. Let |continue| be the result of [=firing a push-replace-reload navigate event=] at |navigation| given "[=NavigationType/replace=]", |activationURL|, and true.
-       <p class="issue">Should we do this or just do the update without the event? TODO: resolve before submit
+    1. Let |continue| be the result of <a>firing a push/replace/reload <code>navigate</code> event</a> at |navigation| given "[=NavigationType/replace=]", |activationURL|, and true.
 
     1. If |continue| is true, run the [=URL and history update steps=] given |successorDocument| and |activationURL|.
 
@@ -441,16 +440,14 @@ Every {{Document}} has an <dfn for="Document">activation start time</dfn>, which
 <div algorithm>
   To <dfn>find a matching complete prerender record</dfn> given a {{Document}} |predecessorDocument| and [=URL=] |url|:
 
-    1. Let |exactRecord| be null.
-    1. Let |inexactRecord| be null.
+    1. Let |recordToUse| be null.
     1. [=list/For each=] |record| of |predecessorDocument|'s [=Document/prerender records=]:
         1. If |record|'s [=prerender record/prerendering traversable=]'s [=navigable/active document=]'s [=Document/is initial about:blank=] is true, then [=iteration/continue=].
         1. If |record|'s [=prerender record/starting URL=] is equal to |url|:
-            1. Set |exactRecord| to |record|.
+            1. Set |recordToUse| to |record|.
             1. [=iteration/Break=].
-        1. If |inexactRecord| is null and |record| [=prerender record/matches a URL=] given |url|:
-            1. Set |inexactRecord| to |record|.
-    1. Let |recordToUse| be |exactRecord| if |exactRecord| is not null, otherwise |inexactRecord|.
+        1. If |recordToUse| is null and |record| [=prerender record/matches a URL=] given |url|:
+            1. Set |recordToUse| to |record|.
     1. If |recordToUse| is not null:
         1. [=list/Remove=] |recordToUse| from |predecessorDocument|'s [=Document/prerender records=].
     1. Return |recordToUse|.
@@ -554,9 +551,9 @@ Patch the [=navigate=] algorithm to allow the [=prerendering traversable/activat
 
     1. Return.
 
-  1. If |navigable| is a [=prerendering traversable=] and |navigable|'s [=prerendering traversable/initial prerender search variance=] is null:
+  1. If |navigable| is a [=prerendering traversable=] and |navigable|'s [=prerendering traversable/prerender initial response search variance=] is null:
 
-    1. Set |navigable|'s [=prerendering traversable/initial prerender search variance=] to the result of [=obtaining a URL search variance=] given |navigationParams|'s [=navigation params/response=].
+    1. Set |navigable|'s [=prerendering traversable/prerender initial response search variance=] to the result of [=obtaining a URL search variance=] given |navigationParams|'s [=navigation params/response=].
 
 </div>
 

--- a/prerendering.bs
+++ b/prerendering.bs
@@ -89,6 +89,7 @@ spec: nav-speculation; urlPrefix: prefetch.html
   type: dfn
     text: supports prefetch; url: supports-prefetch
     text: list of sufficiently-strict speculative navigation referrer policies
+    text: wait for a matching prefetch record; url: wait-for-a-matching-prefetch-record
 spec: RFC8941; urlPrefix: https://www.rfc-editor.org/rfc/rfc8941.html
   type: dfn
     text: structured header; url: #section-1
@@ -202,6 +203,8 @@ By default, a [=navigable=]'s [=navigable/loading mode=] is "`default`". A navig
 
 <p class="note">Although there are only two values for the [=navigable/loading mode=], we use a flexible structure in anticipation of other future loading modes, such as those provided by fenced frames, portals, and uncredentialed (cross-site) prerendering. It's not yet clear whether that anticipation is correct; if, as those features gain full specifications, it turns out not to be, we will instead convert this into a boolean.
 
+Every [=prerendering traversable=] has an <dfn for="prerendering traversable">initial prerender search variance</dfn>, which is a [=URL search variance=] or null, and is initially null.
+
 <dl class="domintro">
   <dt><code><var ignore>document</var>.{{Document/prerendering}}</code></dt>
 
@@ -211,8 +214,6 @@ By default, a [=navigable=]'s [=navigable/loading mode=] is "`default`". A navig
 The <dfn attribute for="Document">prerendering</dfn> getter steps are to return true if [=this=] has a non-null [=node navigable=] that is a [=prerendering navigable=]; otherwise, false.
 
 <hr>
-
-Every [=navigable=] has a <dfn for="navigable">initial prerender search variance</dfn>, which is a [=URL search variance=] or null, and is initially null.
 
 Every {{Document}} has <dfn export for="Document">prerender records</dfn>, which is a [=list=] of [=prerender records=]. This is used to fulfill [=navigate|navigations=] to a given URL by instead [=prerendering traversable/activating=] the corresponding prerendering traversable.
 
@@ -225,7 +226,7 @@ A <dfn export>prerender record</dfn> is a [=struct=] with the following [=struct
 <div algorithm>
     A [=prerender record=] |prerenderRecord| <dfn export for="prerender record">matches a URL</dfn> given a [=URL=] |url| if the following algorithm returns true:
     1. If |prerenderRecord|'s [=prerender record/starting URL=] is equal to |url|, return true.
-    1. Let |searchVariance| be |prerenderRecord|'s [=prerender record/prerendering traversable=]'s [=navigable/initial prerender search variance=].
+    1. Let |searchVariance| be |prerenderRecord|'s [=prerender record/prerendering traversable=]'s [=prerendering traversable/initial prerender search variance=].
     1. If |searchVariance| is not null:
       1. If |prerenderRecord|'s [=prerender record/starting URL=] and |url| are [=equivalent modulo search variance=] given |searchVariance|, return true.
     1. Otherwise, return false.
@@ -234,7 +235,7 @@ A <dfn export>prerender record</dfn> is a [=struct=] with the following [=struct
 <div algorithm>
     A [=prerender record=] |prerenderRecord| <dfn export for="prerender record">is expected to match a URL</dfn> given a [=URL=] |url| if the following algorithm returns true:
     1. If |prerenderRecord| [=prerender record/matches a URL=] given |url|, return true.
-    1. If |prerenderRecord|'s [=prerender record/prerendering traversable=]'s [=navigable/initial prerender search variance=] is null:
+    1. If |prerenderRecord|'s [=prerender record/prerendering traversable=]'s [=prerendering traversable/initial prerender search variance=] is null:
       1. Let |searchVariance| be |prerenderRecord|'s [=prerender record/No-Vary-Search hint=].
       1. If |prerenderRecord|'s [=prerender record/starting URL=] and |url| are [=equivalent modulo search variance=] given |searchVariance|, return true.
     1. Otherwise, return false.
@@ -269,11 +270,11 @@ Every {{Document}} has an <dfn for="Document">activation start time</dfn>, which
 
   1. Let |record| be a [=prerender record=] with [=prerender record/starting URL=] |startingURL| and [=prerender record/prerendering traversable=] |prerenderingTraversable|.
 
-  1. When the user indicates they wish to commit a navigation to an |activationUrl| which is a [=URL=] such that |record| [=prerender record/matches a URL=] given |activationUrl|:
+  1. When the user indicates they wish to commit a navigation to an |activationURL| which is a [=URL=] such that |record| [=prerender record/matches a URL=] given |activationURL|:
 
     1. If the user indicates they wish to create a new user-visible [=top-level traversable=] while doing so (e.g., by pressing <kbd><kbd>Shift</kbd>+<kbd>Enter</kbd></kbd> after typing in the address bar):
 
-      1. TODO update URL
+      1. [=prerendering traversable/Update the successor for activation=] given |prerenderingTraversable|, |startingURL|, and |activationURL|.
 
       1. Update the user agent's user interface to present |prerenderingTraversable|, e.g., by creating a new tab/window.
 
@@ -281,7 +282,7 @@ Every {{Document}} has an <dfn for="Document">activation start time</dfn>, which
 
     1. Alternately, if the user indicates they wish to commit the navigation into an existing [=top-level traversable=] |predecessorTraversable| (e.g., by pressing <kbd>Enter</kbd> after typing in the address bar):
 
-      1. [=prerendering traversable/Activate=] |prerenderingTraversable| in place of |predecessorTraversable| given "`push`", |startingURL|, and |activationUrl|.
+      1. [=prerendering traversable/Activate=] |prerenderingTraversable| in place of |predecessorTraversable| given "`push`", |startingURL|, and |activationURL|.
 
   <p class="note">The user might never indicate such a commitment, or might take long enough to do so that the user agent needs to reclaim the resources used by the prerender for some more immediate task. In that case the user agent can [=destroy a top-level traversable|destroy=] |prerenderingTraversable|.
 </div>
@@ -323,7 +324,28 @@ Every {{Document}} has an <dfn for="Document">activation start time</dfn>, which
 
 <div algorithm>
 
-  To <dfn for="prerendering traversable">activate</dfn> a [=prerendering traversable=] |successorTraversable| in place of a [=top-level traversable=] |predecessorTraversable| given a [=history handling behavior=] |historyHandling|, a [=URL=] |startingUrl|, a [=URL=] |activationUrl|, an optional [=navigation ID=] |navigationId|:
+  To <dfn for="prerendering traversable">update the successor for activation</dfn> given a [=prerendering traversable=] |successorTraversable|, a [=URL=] |startingURL|, and a [=URL=] |activationURL|:
+
+  1. Let |successorDocument| be |successorTraversable|'s [=navigable/active document=].
+
+  1. If |startingURL| equals |successorDocument|'s [=Document/URL=] and |startingURL| does not equal |activationURL|:
+
+    1. [=Assert=]: |successorDocument| [=can have its URL rewritten=] to |activationURL|.
+
+    1. Let |navigation| be |successorDocument|'s [=relevant global object=]'s [=navigation API=].
+
+    1. Let |continue| be the result of [=firing a push-replace-reload navigate event=] at |navigation| given "[=NavigationType/replace=]", |activationURL|, and true.
+       <p class="issue">Should we do this or just do the update without the event? TODO: resolve before submit
+
+    1. If |continue| is true, run the [=URL and history update steps=] given |successorDocument| and |activationURL|.
+
+    <p class="note">This allows for the URL of the prerender to match the URL actually navigated to, in the case of inexact matching based on [:No-Vary-Search:].
+
+</div>
+
+<div algorithm>
+
+  To <dfn for="prerendering traversable">activate</dfn> a [=prerendering traversable=] |successorTraversable| in place of a [=top-level traversable=] |predecessorTraversable| given a [=history handling behavior=] |historyHandling|, a [=URL=] |startingURL|, a [=URL=] |activationURL|, an optional [=navigation ID=] |navigationId|:
 
   1. [=Assert=]: |successorTraversable|'s [=navigable/active document=]'s [=Document/is initial about:blank=] is false.
 
@@ -343,20 +365,7 @@ Every {{Document}} has an <dfn for="Document">activation start time</dfn>, which
 
     1. [=Queue a global task=] on the [=navigation and traversal task source=] given |predecessorTraversable|'s [=navigable/active window=] to [=Document/abort=] |predecessorTraversable|'s [=navigable/active document=].
 
-    1. Let |successorDocument| be |successorTraversable|'s [=navigable/active document=].
-
-    1. If |startingUrl| equals |successorDocument|'s [=Document/URL=] and |startingUrl| does not equal |activationUrl|:
-
-      1. [=Assert=]: |successorDocument| [=can have its URL rewritten=] to |activationUrl|.
-
-      1. Let |navigation| be |successorDocument|'s [=relevant global object=]'s [=navigation API=].
-
-      1. Let |continue| be the result of [=firing a push-replace-reload navigate event=] at |navigation| given "[=NavigationType/replace=]", |activationUrl|, and true.
-         <p class="issue">Should we do this or just do the update without the event? TODO: resolve before submit
-
-      1. If |continue| is true, run the [=URL and history update steps=] given |successorDocument| and |activationUrl|.
-
-      <p class="note">This allows for the URL of the prerender to match the URL actually navigated to, in the case of inexact matching based on [:No-Vary-Search:].
+    1. [=prerendering traversable/Update the successor for activation=] given |successorTraversable|, |startingURL|, and |activationURL|.
 
     1. [=traversable navigable/Append session history traversal steps=] to |predecessorTraversable| to perform the following steps:
 
@@ -477,6 +486,8 @@ Every {{Document}} has an <dfn for="Document">activation start time</dfn>, which
       1. Wait until the [=navigable/ongoing navigation=] of the [=prerender record/prerendering traversable=] of any element of |predecessorDocument|'s [=Document/prerender records=] changes.
       1. If |cutoffTime| is null and any element of |potentialRecords| has a [=prerender record/prerendering traversable=] whose [=navigable/active document=]'s [=Document/is initial about:blank=] is false, set |cutoffTime| to the [=current high resolution time=] for the [=relevant global object=] of |predecessorDocument|.
 
+    <p class="note">See also: [=wait for a matching prefetch record=]. The logic for blocking on ongoing prerenders is similar to the prefetch case.</p>
+
 </div>
 
 Patch the [=navigate=] algorithm to allow the [=prerendering traversable/activate|activation=] of a [=prerendering traversable=] in place of a normal navigation as follows:
@@ -487,11 +498,12 @@ Patch the [=navigate=] algorithm to allow the [=prerendering traversable/activat
   1. Let |matchingPrerenderRecord| be the result of [=waiting for a matching prerendering record=] given |navigable|, <var ignore>url</var>, <var ignore>cspNavigationType</var>, and <var ignore>documentResource</var>.
 
   1. If |matchingPrerenderRecord| is not null, then:
+
       1. Let |matchingPrerenderedNavigable| be |matchingPrerenderRecord|'s [=prerender record/prerendering traversable=].
 
-      1. Let |startingUrl| be |matchingPrerenderRecord|'s [=prerender record/starting URL=].
+      1. Let |startingURL| be |matchingPrerenderRecord|'s [=prerender record/starting URL=].
 
-      1. [=prerendering traversable/Activate=] |matchingPrerenderedNavigable| in place of |navigable| given <var ignore>historyHandling</var>, |startingUrl|, <var ignore>url</var>, and <var ignore>navigationId</var>.
+      1. [=prerendering traversable/Activate=] |matchingPrerenderedNavigable| in place of |navigable| given <var ignore>historyHandling</var>, |startingURL|, <var ignore>url</var>, and <var ignore>navigationId</var>.
 
       1. Abort these steps.
 </div>
@@ -542,8 +554,9 @@ Patch the [=navigate=] algorithm to allow the [=prerendering traversable/activat
 
     1. Return.
 
-  1. If |navigable| is a [=prerendering navigable=] and |navigable|'s [=navigable/initial prerender search variance=] is null:
-    1. Set |navigable|'s [=navigable/initial prerender search variance=] to the result of [=obtaining a URL search variance=] given |navigationParams|'s [=navigation params/response=].
+  1. If |navigable| is a [=prerendering traversable=] and |navigable|'s [=prerendering traversable/initial prerender search variance=] is null:
+
+    1. Set |navigable|'s [=prerendering traversable/initial prerender search variance=] to the result of [=obtaining a URL search variance=] given |navigationParams|'s [=navigation params/response=].
 
 </div>
 

--- a/prerendering.bs
+++ b/prerendering.bs
@@ -27,6 +27,7 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
   type: dfn
     text: active needed worker; url: workers.html#active-needed-worker
     text: attempt to populate the history entry's document; url: browsing-the-web.html#attempt-to-populate-the-history-entry's-document
+    text: can have its URL rewritten; url: nav-history-apis.html#can-have-its-url-rewritten
     text: check if unloading is user-canceled; url: browsing-the-web.html#checking-if-unloading-is-user-canceled
     text: create a new child navigable; url: document-sequences.html#create-a-new-child-navigable
     text: create a new top-level traversable; url: document-sequences.html#creating-a-new-top-level-traversable
@@ -34,13 +35,16 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
     text: current playback position; url: media.html#current-playback-position
     text: destroy a top-level traversable; url: document-sequences.html#destroy-a-top-level-traversable
     text: finalize a cross-document navigation; url: browsing-the-web.html#finalize-a-cross-document-navigation
+    text: fire a push-replace-reload navigate event; url: nav-history-apis.html#fire-a-push/replace/reload-navigate-event
     text: hand-off to external software; url: browsing-the-web.html#hand-off-to-external-software
     text: history handling behavior; url: browsing-the-web.html#history-handling-behavior
     text: navigation and traversal task source; url: webappapis.html#navigation-and-traversal-task-source
+    text: navigation API; url: nav-history-apis.html#window-navigation-api
     text: navigation ID; url: browsing-the-web.html#navigation-id
     text: playing the media resource; url: media.html#playing-the-media-resource
     text: session history entry; url: browsing-the-web.html#session-history-entry
     text: the worker's lifetime; url: workers.html#the-worker's-lifetime
+    text: URL and history update steps; url: browsing-the-web.html#url-and-history-update-steps
     for: Document
       text: abort; url: document-lifecycle.html#abort-a-document
       text: destroy; url: document-lifecycle.html#destroy-a-document
@@ -55,6 +59,8 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
     for: navigation params
       text: request; url: browsing-the-web.html#navigation-params-request
       text: response; url: browsing-the-web.html#navigation-params-response
+    for: NavigationType
+      text: replace; url: nav-history-apis.html#dom-navigationtype-replace
     for: session history entry
       text: document state; url: browsing-the-web.html#she-document-state
       text: document; url: browsing-the-web.html#she-document
@@ -73,6 +79,12 @@ spec: picture-in-picture; urlPrefix: https://w3c.github.io/picture-in-picture/
 spec: mediacapture-main; urlPrefix: https://w3c.github.io/mediacapture-main/
   type: dfn
     text: device change notification steps; url: dfn-device-change-notification-steps
+spec: nav-speculation; urlPrefix: no-vary-search.html
+  type: dfn
+    text: URL search variance; url: url-search-variance
+    text: default URL search variance; url: default-url-search-variance
+    text: obtain a URL search variance; url: obtain-a-url-search-variance
+    text: equivalent modulo search variance; url: equivalent-modulo-search-variance
 spec: nav-speculation; urlPrefix: prefetch.html
   type: dfn
     text: supports prefetch; url: supports-prefetch
@@ -200,7 +212,33 @@ The <dfn attribute for="Document">prerendering</dfn> getter steps are to return 
 
 <hr>
 
-Every {{Document}} has a <dfn for="Document">prerendering traversables map</dfn>, which is an [=ordered map=] of [=URLs=] to [=prerendering traversables=]. This is used to fulfill [=navigate|navigations=] to a given URL by instead [=prerendering traversable/activating=] the corresponding prerendering traversable.
+Every [=navigable=] has a <dfn for="navigable">initial prerender search variance</dfn>, which is a [=URL search variance=] or null, and is initially null.
+
+Every {{Document}} has <dfn export for="Document">prerender records</dfn>, which is a [=list=] of [=prerender records=]. This is used to fulfill [=navigate|navigations=] to a given URL by instead [=prerendering traversable/activating=] the corresponding prerendering traversable.
+
+A <dfn export>prerender record</dfn> is a [=struct=] with the following [=struct/items=]:
+* <dfn export for="prerender record">starting URL</dfn>, a [=URL=]
+* <dfn export for="prerender record">No-Vary-Search hint</dfn>, a [=URL search variance=] (the [=default URL search variance=] by default)
+* <dfn export for="prerender record">start time</dfn>, a {{DOMHighResTimeStamp}} (0.0 by default)
+* <dfn export for="prerender record">prerendering traversable</dfn>, a [=prerendering traversable=]
+
+<div algorithm>
+    A [=prerender record=] |prerenderRecord| <dfn export for="prerender record">matches a URL</dfn> given a [=URL=] |url| if the following algorithm returns true:
+    1. If |prerenderRecord|'s [=prerender record/starting URL=] is equal to |url|, return true.
+    1. Let |searchVariance| be |prerenderRecord|'s [=prerender record/prerendering traversable=]'s [=navigable/initial prerender search variance=].
+    1. If |searchVariance| is not null:
+      1. If |prerenderRecord|'s [=prerender record/starting URL=] and |url| are [=equivalent modulo search variance=] given |searchVariance|, return true.
+    1. Otherwise, return false.
+</div>
+
+<div algorithm>
+    A [=prerender record=] |prerenderRecord| <dfn export for="prerender record">is expected to match a URL</dfn> given a [=URL=] |url| if the following algorithm returns true:
+    1. If |prerenderRecord| [=prerender record/matches a URL=] given |url|, return true.
+    1. If |prerenderRecord|'s [=prerender record/prerendering traversable=]'s [=navigable/initial prerender search variance=] is null:
+      1. Let |searchVariance| be |prerenderRecord|'s [=prerender record/No-Vary-Search hint=].
+      1. If |prerenderRecord|'s [=prerender record/starting URL=] and |url| are [=equivalent modulo search variance=] given |searchVariance|, return true.
+    1. Otherwise, return false.
+</div>
 
 Every {{Document}} has a <dfn for="Document">post-prerendering activation steps list</dfn>, which is a [=list=] where each [=list/item=] is a series of algorithm steps. For convenience, we define the <dfn for="platform object">post-prerendering activation steps list</dfn> for any platform object |platformObject| as:
 
@@ -243,7 +281,7 @@ Every {{Document}} has an <dfn for="Document">activation start time</dfn>, which
 </div>
 
 <div>
-  To <dfn export>start referrer-initiated prerendering</dfn> given a [=URL=] |startingURL|, a {{Document}} |referrerDoc|, and a [=referrer policy=] |referrerPolicy|:
+  To <dfn export>start referrer-initiated prerendering</dfn> given a [=URL=] |startingURL|, a {{Document}} |referrerDoc|, a [=referrer policy=] |referrerPolicy|, and a [=URL search variance=] |nvsHint|:
 
   1. [=Assert=]: |startingURL|'s [=url/scheme=] is an [=HTTP(S) scheme=].
 
@@ -259,15 +297,18 @@ Every {{Document}} has an <dfn for="Document">activation start time</dfn>, which
 
      <p class="note">Currently, cross-site prerendering is not specified or implemented, although we have various ideas about how it could work in this repository's explainers.
 
-  1. If |referrerDoc|'s [=Document/prerendering traversables map=][|startingURL|] [=map/exists=], then return.
+  1. [=list/For each=] |record| of |referrerDoc|'s [=Document/prerender records=]:
+      1. If |record|'s [=prerender record/starting URL=] is |startingURL|, then return.
 
   1. Let |prerenderingTraversable| be the result of [=creating a new top-level traversable=].
 
   1. Set |prerenderingTraversable|'s [=navigable/loading mode=] to "`prerender`".
 
-  1. Set |referrerDoc|'s [=Document/prerendering traversables map=][|startingURL|] to |prerenderingTraversable|.
+  1. Let |prerenderRecord| be a [=prerender record=] with [=prerender record/starting URL=] |startingURL|, [=prerender record/No-Vary-Search hint=] |nvsHint|, [=prerender record/start time=] the [=current high resolution time=] for the [=relevant global object=] of |referrerDoc|, and [=prerender record/prerendering traversable=] |prerenderingTraversable|.
 
-  1. Set |prerenderingTraversable|'s [=prerendering traversable/remove from referrer=] to be an algorithm which [=map/removes=] |referrerDoc|[|startingURL|].
+  1. [=list/Append=] |prerenderRecord| to |referrerDoc|'s [=Document/prerender records=].
+
+  1. Set |prerenderingTraversable|'s [=prerendering traversable/remove from referrer=] to be an algorithm which [=list/removes=] |prerenderRecord| from |referrerDoc|'s [=Document/prerender records=].
 
      <p class="note">As with all [=top-level traversables=], the [=prerendering traversable=] can be [=destroy a top-level traversable|destroyed=] for any reason, for example if it becomes unresponsive, performs a restricted operation, or if the user agent believes prerendering takes too many resources.
 
@@ -275,7 +316,8 @@ Every {{Document}} has an <dfn for="Document">activation start time</dfn>, which
 </div>
 
 <div algorithm>
-  To <dfn for="prerendering traversable">activate</dfn> a [=prerendering traversable=] |successorTraversable| in place of a [=top-level traversable=] |predecessorTraversable| given a [=history handling behavior=] |historyHandling| and an optional [=navigation ID=] |navigationId|:
+TODO activate call sites
+  To <dfn for="prerendering traversable">activate</dfn> a [=prerendering traversable=] |successorTraversable| in place of a [=top-level traversable=] |predecessorTraversable| given a [=history handling behavior=] |historyHandling|, a [=URL=] |startingUrl|, a [=URL=] |activationUrl|, an optional [=navigation ID=] |navigationId|:
 
   1. [=Assert=]: |successorTraversable|'s [=navigable/active document=]'s [=Document/is initial about:blank=] is false.
 
@@ -294,6 +336,20 @@ Every {{Document}} has an <dfn for="Document">activation start time</dfn>, which
     1. If |unloadPromptCanceled| is true, or |predecessorTraversable|'s [=navigable/ongoing navigation=] is no longer |navigationId|, then abort these steps.
 
     1. [=Queue a global task=] on the [=navigation and traversal task source=] given |predecessorTraversable|'s [=navigable/active window=] to [=Document/abort=] |predecessorTraversable|'s [=navigable/active document=].
+
+    1. Let |successorDocument| be |successorTraversable|'s [=navigable/active document=].
+
+    1. If |startingUrl| equals |successorDocument|'s [=Document/URL=] and |startingUrl| does not equal |activationUrl|:
+
+      1. [=Assert=]: |successorDocument| [=can have its URL rewritten=] to |activationUrl|.
+
+      1. Let |navigation| be |successorDocument|'s [=relevant global object=]'s [=navigation API=].
+
+      1. Let |continue| be the result of [=firing a push-replace-reload navigate event=] at |navigation| given "[=NavigationType/replace=]", |activationUrl|, and true.
+
+      1. If |continue| is true, run the [=URL and history update steps=] given |successorDocument| and |activationUrl|.
+
+      <p class="note">This allows for the URL of the prerender to match the URL actually navigated to, in the case of inexact matching based on [:No-Vary-Search:].
 
     1. [=traversable navigable/Append session history traversal steps=] to |predecessorTraversable| to perform the following steps:
 
@@ -366,9 +422,28 @@ Every {{Document}} has an <dfn for="Document">activation start time</dfn>, which
 
 <h3 id="navigate-activation">Allowing activation in place of navigation</h3>
 
-<div>
-  To <dfn>get the matching prerendering navigable</dfn> given a [=navigable=] |navigable|, a [=URL=] |url|, a string |cspNavigationType|, and a [=POST resource=], string, or null |documentResource|:
+<div algorithm>
+  To <dfn>find a matching complete prerender record</dfn> given a {{Document}} |predecessorDocument| and [=URL=] |url|:
 
+    1. Let |exactRecord| be null.
+    1. Let |inexactRecord| be null.
+    1. [=list/For each=] |record| of |predecessorDocument|'s [=Document/prerender records=]:
+        1. If |record|'s [=prerender record/prerendering traversable=]'s [=navigable/active document=]'s [=Document/is initial about:blank=] is true, then [=iteration/continue=].
+        1. If |record|'s [=prerender record/starting URL=] is equal to |url|:
+            1. Set |exactRecord| to |record|.
+            1. [=iteration/Break=].
+        1. If |inexactRecord| is null and |record| [=prerender record/matches a URL=] given |url|:
+            1. Set |inexactRecord| to |record|.
+    1. Let |recordToUse| be |exactRecord| if |exactRecord| is not null, otherwise |inexactRecord|.
+    1. If |recordToUse| is not null:
+        1. [=list/Remove=] |recordToUse| from |predecessorDocument|'s [=Document/prerender records=].
+    1. Return |recordToUse|.
+</div>
+
+<div algorithm>
+  To <dfn>wait for a matching prerendering navigable</dfn> given a [=navigable=] |navigable|, a [=URL=] |url|, a string |cspNavigationType|, and a [=POST resource=], string, or null |documentResource|:
+
+  1. [=Assert=]: this is running [=in parallel=].
   1. If any of the following conditions hold:
 
       * |navigable| is not a [=top-level traversable=];
@@ -380,7 +455,21 @@ Every {{Document}} has an <dfn for="Document">activation start time</dfn>, which
 
     then return null.
 
-  1. Return |navigable|'s [=navigable/active document=]'s [=Document/prerendering traversables map=][|url|], if it [=map/exists=]; otherwise return null.
+  1. Let |predecessorDocument| be |navigable|'s [=navigable/active document=].
+  1. Let |cutoffTime| be null.
+  1. While true:
+      1. Let |completeRecord| be the result of [=finding a matching complete prerender record=] given |predecessorDocument| and |url|.
+      1. If |completeRecord| is not null, return |completeRecord|'s [=prerender record/prerendering traversable=].
+      1. Let |potentialRecords| be an empty [=list=].
+      1. [=list/For each=] |record| of |predecessorDocument|'s [=Document/prerender records=]:
+          1. If all of the following are true, then [=list/append=] |record| to |potentialRecords|:
+              * |record|'s [=prerender record/prerendering traversable=]'s [=navigable/active document=]'s [=Document/is initial about:blank=] is true.
+              * |record| [=prerender record/is expected to match a URL=] given |url|.
+              * |cutoffTime| is null or |record|'s [=prerender record/start time=] is less than |cutoffTime|.
+      1. If |potentialRecords| [=list/is empty=], return null.
+      1. Wait until the [=navigable/ongoing navigation=] of the [=prerender record/prerendering traversable=] of any element of |predecessorDocument|'s [=Document/prerender records=] changes.
+      1. If |cutoffTime| is null and any element of |potentialRecords| has a [=prerender record/prerendering traversable=] whose [=navigable/active document=]'s [=Document/is initial about:blank=] is false, set |cutoffTime| to the [=current high resolution time=] for the [=relevant global object=] of |predecessorDocument|.
+
 </div>
 
 Patch the [=navigate=] algorithm to allow the [=prerendering traversable/activate|activation=] of a [=prerendering traversable=] in place of a normal navigation as follows:
@@ -388,13 +477,9 @@ Patch the [=navigate=] algorithm to allow the [=prerendering traversable/activat
 <div algorithm="navigate activate patch">
   In [=navigate=], insert the following steps as the first ones after we go [=in parallel=]:
 
-  1. Let |matchingPrerenderedNavigable| be the result of [=getting the matching prerendering navigable=] given |navigable|, <var ignore>url</var>, <var ignore>cspNavigationType</var>, and <var ignore>documentResource</var>.
+  1. Let |matchingPrerenderedNavigable| be the result of [=waiting for a matching prerendering navigable=] given |navigable|, <var ignore>url</var>, <var ignore>cspNavigationType</var>, and <var ignore>documentResource</var>.
 
   1. If |matchingPrerenderedNavigable| is not null, then:
-
-    1. Wait until either |matchingPrerenderedNavigable|'s [=navigable/active document=]'s [=Document/is initial about:blank=] is false, or |matchingPrerenderedNavigable| is [=destroy a top-level traversable|destroyed=].
-
-    1. If |matchingPrerenderedNavigable| was not destroyed, then:
 
       1. [=prerendering traversable/Activate=] |matchingPrerenderedNavigable| in place of |navigable| given <var ignore>historyHandling</var> and <var ignore>navigationId</var>.
 
@@ -446,6 +531,10 @@ Patch the [=navigate=] algorithm to allow the [=prerendering traversable/activat
     1. [=destroy a top-level traversable|Destroy=] |navigable|'s [=navigable/top-level traversable=].
 
     1. Return.
+
+  1. If |navigable| is a [=prerendering navigable=] and |navigable|'s [=navigable/initial prerender search variance=] is null:
+    1. Set |navigable|'s [=navigable/initial prerender search variance=] to the result of [=obtaining a URL search variance=] given |navigationParams|'s [=navigation params/response=].
+
 </div>
 
 <div algorithm="hand-off to external software patch">

--- a/speculation-rules.bs
+++ b/speculation-rules.bs
@@ -520,6 +520,7 @@ A <dfn>prerender candidate</dfn> is a [=struct=] with the following [=struct/ite
 * <dfn for="prerender candidate">target navigable name hint</dfn>, a [=valid navigable target name or keyword=] or null
 * <dfn for="prerender candidate">referrer policy</dfn>, a [=referrer policy=]
 * <dfn for="prerender candidate">eagerness</dfn>, one of the [=valid eagerness strings=]
+* <dfn for="prerender candidate">No-Vary-Search hint</dfn>, a [=URL search variance=]
 
 <div algorithm>
   A [=prefetch candidate=] |prefetchCandidate| <dfn for="prefetch candidate">continues</dfn> a [=prefetch record=] |prefetchRecord| if the following are all true:
@@ -582,7 +583,7 @@ A <dfn>prerender candidate</dfn> is a [=struct=] with the following [=struct/ite
     1. &#x231B; [=list/For each=] |rule| of |ruleSet|'s [=speculation rule set/prerender rules=]:
       1. &#x231B; [=list/For each=] |url| of |rule|'s [=speculation rule/URLs=]:
         1. &#x231B; Let |referrerPolicy| be the result of [=computing a speculative action referrer policy=] given |rule| and null.
-        1. &#x231B; Let |prerenderCandidate| be a new [=prerender candidate=] whose [=prerender candidate/URL=] is |url|, [=prerender candidate/target navigable name hint=] is |rule|'s [=speculation rule/target navigable name hint=], [=prerender candidate/referrer policy=] is |referrerPolicy|, and [=prerender candidate/eagerness=] is |rule|'s [=speculation rule/eagerness=].
+        1. &#x231B; Let |prerenderCandidate| be a new [=prerender candidate=] whose [=prerender candidate/URL=] is |url|, [=prerender candidate/target navigable name hint=] is |rule|'s [=speculation rule/target navigable name hint=], [=prerender candidate/referrer policy=] is |referrerPolicy|, [=prerender candidate/eagerness=] is |rule|'s [=speculation rule/eagerness=], and [=prerender candidate/No-Vary-Search hint=] is |rule|'s [=speculation rule/No-Vary-Search hint=].
         1. &#x231B; [=list/Append=] |prerenderCandidate| to |prerenderCandidates|.
       1. &#x231B; If |rule|'s [=speculation rule/predicate=] is not null, then:
         1. &#x231B; Let |links| be the result of [=finding matching links=] given |document| and |rule|'s [=speculation rule/predicate=].
@@ -591,7 +592,7 @@ A <dfn>prerender candidate</dfn> is a [=struct=] with the following [=struct/ite
           1. &#x231B; Let |target| be |rule|'s [=speculation rule/target navigable name hint=].
           1. &#x231B; If |target| is null, set it to the result of [=getting an element's target=] given |link|.
           1. &#x231B; Let |referrerPolicy| be the result of [=computing a speculative action referrer policy=] given |rule| and |link|.
-          1. &#x231B; Let |prerenderCandidate| be a new [=prerender candidate=] whose [=prerender candidate/URL=] is |url|, [=prerender candidate/target navigable name hint=] is |target|, [=prerender candidate/referrer policy=] is |referrerPolicy|, and [=prerender candidate/eagerness=] is |rule|'s [=speculation rule/eagerness=].
+          1. &#x231B; Let |prerenderCandidate| be a new [=prerender candidate=] whose [=prerender candidate/URL=] is |url|, [=prerender candidate/target navigable name hint=] is |target|, [=prerender candidate/referrer policy=] is |referrerPolicy|, [=prerender candidate/eagerness=] is |rule|'s [=speculation rule/eagerness=], and [=prerender candidate/No-Vary-Search hint=] is |rule|'s [=speculation rule/No-Vary-Search hint=].
           1. &#x231B; [=list/Append=] |prerenderCandidate| to |prerenderCandidates|.
   1. &#x231B; [=list/For each=] |prefetchRecord| of |document|'s [=Document/prefetch records=]:
     1. &#x231B; If |prefetchRecord|'s [=prefetch record/label=] is not "`speculation-rules`", then [=iteration/continue=].
@@ -603,7 +604,7 @@ A <dfn>prerender candidate</dfn> is a [=struct=] with the following [=struct/ite
       1. Let |prefetchRecord| be a new [=prefetch record=] whose [=prefetch record/URL=] is |prefetchCandidate|'s [=prefetch candidate/URL=], [=prefetch record/anonymization policy=] is |prefetchCandidate|'s [=prefetch candidate/anonymization policy=], [=prefetch record/referrer policy=] is |prefetchCandidate|'s [=prefetch candidate/referrer policy=], [=prefetch record/No-Vary-Search hint=] is |prefetchCandidate|'s [=prefetch candidate/No-Vary-Search hint=], and [=prefetch record/label=] is "`speculation-rules`".
       1. [=Prefetch=] given |document| and |prefetchRecord|.
   1. [=list/For each=] |prerenderCandidate| of |prerenderCandidates|:
-      1. The user agent may [=start referrer-initiated prerendering=] given |prerenderCandidate|'s [=prerender candidate/URL=], |document|, and |prerenderCandidate|'s [=prerender candidate/referrer policy=].
+      1. The user agent may [=start referrer-initiated prerendering=] given |prerenderCandidate|'s [=prerender candidate/URL=], |document|, |prerenderCandidate|'s [=prerender candidate/referrer policy=], and |prerenderCandidate|'s [=prerender candidate/No-Vary-Search hint=].
 
          The user agent can use |prerenderCandidate|'s [=prerender candidate/target navigable name hint=] as a hint to their implementation of the [=start referrer-initiated prerendering=] algorithm. This hint indicates that the web developer expects the eventual [=prerendering traversable/activate|activation=] of the created [=prerendering traversable=] to be in place of a particular predecessor traversable: the one that would be chosen by the invoking the [=rules for choosing a navigable=] given |prerenderCandidate|'s [=prerender candidate/target navigable name hint=] and |document|'s [=node navigable=].
 


### PR DESCRIPTION
The NVS hint from the speculation rule, if any, is now passed to the prerender creation.

The map of URLs to prerendering traversables is replaced with a list of a struct containing additional information about the prerender to support more flexible matching.

When the initial navigation of a prerendering traversable commits, we record its No-Vary-Search value.

When getting a prerender to activate, we now wait on potentially multiple ongoing prerenders that could match based on the NVS hint. This logic is similar to the prefetch case.

During activation, we update the prerender's URL if there is a difference in the prerendered document's URL and the URL navigated to in the case of inexact matching due to NVS.