### PR TITLE
Editorial: Fix HTTP header link for No-Vary-Search in prerendering spec

### DIFF
--- a/prerendering.bs
+++ b/prerendering.bs
@@ -85,6 +85,8 @@ spec: no-vary-search; urlPrefix: https://httpwg.org/http-extensions/draft-ietf-h
     text: default URL search variance; url: iref-default-url-search-variance
     text: obtain a URL search variance; url: name-obtain-a-url-search-varianc
     text: equivalent modulo search variance; url: name-comparing
+  type: http-header
+    text: No-Vary-Search; url: name-http-header-field-definitio
 spec: nav-speculation; urlPrefix: prefetch.html
   type: dfn
     text: supports prefetch; url: supports-prefetch


### PR DESCRIPTION
Fixes #344.