### PR TITLE
Make it more obvious that prefetches only fulfill GET requests

### DIFF
--- a/prefetch.bs
+++ b/prefetch.bs
@@ -89,6 +89,7 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
         text: has transient activation; url: source-snapshot-params-activation
         text: source policy container; url: source-snapshot-params-policy-container
         text: fetch client; url: source-snapshot-params-client
+        text: sandboxing flags; url: source-snapshot-params-sandbox
       text: target snapshot params; url: target-snapshot-params
       for: target snapshot params
         text: sandboxing flags; url: target-snapshot-params-sandbox
@@ -534,13 +535,18 @@ Modify the [=snapshot source snapshot params=] algorithm to set the return value
 
             1. Let |request| be the result of [=creating a navigation request=] given <var ignore>entry</var>, <var ignore>sourceSnapshotParams</var>'s [=source snapshot params/fetch client=], <var ignore>navigable</var>'s [=navigable/container=], and <var ignore>sourceSnapshotParams</var>'s [=source snapshot params/has transient activation=].
             1. Set |request|'s [=request/replaces client id=] to <var ignore>navigable</var>'s [=navigable/active document=]'s [=relevant settings object=]'s [=environment/id=].
-            1. Let |prefetchRecord| be the result of [=waiting for a matching prefetch record=] given <var ignore>navigable</var>, <var ignore>sourceSnapshotParams</var>, <var ignore>entry</var>'s [=session history entry/URL=], and <var ignore>targetSnapshotParams</var>'s [=target snapshot params/sandboxing flags=].
-            1. If <var ignore>documentResource</var> is null and |prefetchRecord| is not null:
+            1. Let |prefetched| be false.
+            1. If <var ignore>documentResource</var> is null:
+              1. Let |prefetchRecord| be the result of [=finding a matching complete prefetch record=] given <var ignore>navigable</var>, <var ignore>sourceSnapshotParams</var>, <var ignore>entry</var>'s [=session history entry/URL=], and <var ignore>sourceSnapshotParams</var>'s [=source snapshot params/sandboxing flags=].
+              1. If |prefetchRecord| is not null:
                 1. Set <var ignore>navigationParams</var> to the result of [=creating navigation params from a prefetch record=] given <var ignore>navigable</var>, <var ignore>entry</var>'s [=session history entry/document state=], <var ignore>navigationId</var>, <var ignore>navTimingType</var>, <var ignore>request</var>, |prefetchRecord|, <var ignore>targetSnapshotParams</var>, and <var ignore>sourceSnapshotParams</var>.
                 1. [=Copy prefetch cookies=] given |prefetchRecord|'s [=prefetch record/isolated partition key=] and <var ignore>navigationParams</var>'s [=navigation params/reserved environment=].
 
                     <div class="note">This copy is complete before continuing, in the sense that subresource fetches, {{Document/cookie|document.cookie}}, etc. can observe the cookies. If the prefetch never reached a cross-site URL, there will be no cookies to copy.</div>
-            1. Otherwise:
+                1. Set |prefetched| to true.
+
+                <p class="note">This means that prefetches are only ever used to fulfill \``GET`\` requests.</p>
+            1. If |prefetched| is false:
                 1. Let |coopEnforcementResult| be the result of [=creating a cross-origin opener policy enforcement result for navigation=] given <var ignore>navigable</var>'s [=navigable/active document=] and <var ignore>entry</var>'s [=session history entry/document state=]'s [=document state/initiator origin=].
                 1. Set <var ignore>navigationParams</var> to the result of [=creating navigation params by fetching=] given |request|, <var ignore>entry</var>, |coopEnforcementResult|, <var ignore>navigable</var>, <var ignore>sourceSnapshotParams</var>, <var ignore>targetSnapshotParams</var>, <var ignore>cspNavigationType</var>, <var ignore>navigationId</var>, and <var ignore>navTimingType</var>.
 


### PR DESCRIPTION
The previous structure would do some redundant (unobservable) work to find a matching prefetch record, and then ignore it for POST requests. The new structure is more verbose, but avoids this extra work.

Also, add a note explicitly connecting the documentResource variable to GET requests.