### PR TITLE
Fix request clients for prefetch + service workers

### DIFF
--- a/prefetch.bs
+++ b/prefetch.bs
@@ -363,7 +363,7 @@ The user agent may [=prefetch record/cancel and discard=] records from the [=Doc
     1. [=list/For each=] |exchangeRecord| in |record|'s [=prefetch record/redirect chain=]:
         1. Let |redirectChainRequest| be |exchangeRecord|'s [=exchange record/request=].
         1. Let |redirectChainResponse| be |exchangeRecord|'s [=exchange record/response=].
-        1. [=list/Append=] |redirectChainResponse|'s [=response/URL=] to |urlList|.
+        1. [=list/Append=] |redirectChainRequest|'s [=request/URL=] to |urlList|.
         1. Set |responsePolicyContainer| to the result of [=creating a policy container from a fetch response=] given |redirectChainResponse| and |redirectChainRequest|'s [=request/reserved client=].
         1. Set |finalSandboxFlags| to the [=set/union=] of |targetSnapshotParams|'s [=target snapshot params/sandboxing flags=] and |responsePolicyContainer|'s [=policy container/CSP list=]'s [=CSP-derived sandboxing flags=].
         1. Set |responseOrigin| to the result of [=determining the origin=] given |redirectChainResponse|'s [=response/URL=], |finalSandboxFlags|, |documentState|'s [=document state/initiator origin=], and null.

--- a/prefetch.bs
+++ b/prefetch.bs
@@ -748,16 +748,6 @@ This section contains patches to [[NAVIGATION-TIMING]].
 
 This section contains patches to [[SERVICE-WORKERS]].
 
-<div algorithm="Service worker control">
-  Modify the definition of <a spec="SERVICE-WORKERS">controlled</a> as follows:
-
-  <blockquote>
-    When a [=service worker client=] has a non-null [=environment/active service worker=]<ins> whose [=environment/is navigational prefetch client=] is false</ins>, it is said to be <dfn noexport>controlled</dfn> by that [=environment/active service worker=].
-  </blockquote>
-</div>
-
-<hr>
-
 <div algorithm="Create Fetch Event and Dispatch">
   Modify <a spec="SERVICE-WORKERS">Create Fetch Event and Dispatch</a>'s step which sets {{FetchEvent/resultingClientId}} as follows:
 

--- a/prefetch.bs
+++ b/prefetch.bs
@@ -358,43 +358,33 @@ The user agent may [=prefetch record/cancel and discard=] records from the [=Doc
     1. Let |coopEnforcementResult| be the result of [=creating a cross-origin opener policy enforcement result for navigation=] given |navigable|'s [=navigable/active document=] and |documentState|'s [=document state/initiator origin=].
     1. Let |finalSandboxFlags| be an empty [=sandboxing flag set=].
     1. Let |responsePolicyContainer| be null.
+    1. Let |activeServiceWorker| be null.
     1. Let |urlList| be an empty [=list=].
     1. [=list/For each=] |exchangeRecord| in |record|'s [=prefetch record/redirect chain=]:
-        1. Let |response| be |exchangeRecord|'s [=exchange record/response=].
-        1. [=list/Append=] |response|'s [=response/URL=] to |urlList|.
-        1. Set |responsePolicyContainer| to the result of [=creating a policy container from a fetch response=] given |response| and |request|'s [=request/reserved client=].
+        1. Let |redirectChainRequest| be |exchangeRecord|'s [=exchange record/request=].
+        1. Let |redirectChainResponse| be |exchangeRecord|'s [=exchange record/response=].
+        1. [=list/Append=] |redirectChainResponse|'s [=response/URL=] to |urlList|.
+        1. Set |responsePolicyContainer| to the result of [=creating a policy container from a fetch response=] given |redirectChainResponse| and |redirectChainRequest|'s [=request/reserved client=].
         1. Set |finalSandboxFlags| to the [=set/union=] of |targetSnapshotParams|'s [=target snapshot params/sandboxing flags=] and |responsePolicyContainer|'s [=policy container/CSP list=]'s [=CSP-derived sandboxing flags=].
-        1. Set |responseOrigin| to the result of [=determining the origin=] given |response|'s [=response/URL=], |finalSandboxFlags|, |documentState|'s [=document state/initiator origin=], and null.
+        1. Set |responseOrigin| to the result of [=determining the origin=] given |redirectChainResponse|'s [=response/URL=], |finalSandboxFlags|, |documentState|'s [=document state/initiator origin=], and null.
+        1. Set |activeServiceWorker| to |redirectChainRequest|'s [=request/reserved client=]'s [=environment/active service worker=].
         1. If |navigable| is a [=top-level traversable=], then:
-            1. Set |responseCOOP| to the result of [=obtaining a cross-origin opener policy=] given |response| and |request|'s [=request/reserved client=].
+            1. Set |responseCOOP| to the result of [=obtaining a cross-origin opener policy=] given |redirectChainResponse| and |redirectChainRequest|'s [=request/reserved client=].
             1. [=Assert=]: If |finalSandboxFlags| is not empty, then |responseCOOP|'s [=cross-origin opener policy/value=] is "`unsafe-none`".
 
                 <p class="note">This is guaranteed since the sandboxing flags of the document cannot change to become non-empty since this was prefetched, and the check was not done for a different window. If this changes, this will need to be able to handle failure of this check.</p>
-            1. Set |coopEnforcementResult| to the result of [=enforcing a response's cross-origin opener policy=] given |navigable|'s [=active browsing context=], |response|'s [=response/URL=], |responseOrigin|, |responseCOOP|, |coopEnforcementResult|, and |exchangeRecord|'s [=exchange record/request=]'s [=request/referrer=].
+            1. Set |coopEnforcementResult| to the result of [=enforcing a response's cross-origin opener policy=] given |navigable|'s [=active browsing context=], |redirectChainResponse|'s [=response/URL=], |responseOrigin|, |responseCOOP|, |coopEnforcementResult|, and |exchangeRecord|'s [=exchange record/request=]'s [=request/referrer=].
     1. Set |request|'s [=request/URL list=] to |urlList|.
+    1. <span id="prefetch-activation-client-creation"></span>Set |request|'s [=request/reserved client=] to the result of [=creating a reserved client=] given |navigable| and |request|'s [=request/URL=].
+
+        <p class="note">This will be the [=environment=] used for constructing the resulting {{Document}} and [=environment settings object=]. We need a separate [=environment=] for each time a [=prefetch record=] is consumed, instead of using |record|'s [=prefetch record/redirect chain=]'s last item's [=exchange record/request=]'s [=request/reserved client=], because otherwise reusing the same prefetch record for multiple [=navigation params=] (i.e., multiple navigations) would cause the created [=environment settings objects=] to share an [=environment/id=]. This would then be visible, e.g., through the {{Clients/get()|clients.get()}} API, in a very confusing way.
+    1. Set |request|'s [=request/reserved client=]'s [=environment/active service worker=] to |activeServiceWorker|.
     1. Let |resultPolicyContainer| be the result of [=determining navigation params policy container=] given |record|'s [=prefetch record/response=]'s [=response/URL=], |documentState|'s [=document state/history policy container=], |sourceSnapshotParams|'s [=source snapshot params/source policy container=], null, and |responsePolicyContainer|.
     1. Let |response| be |record|'s [=prefetch record/response=].
     1. Optionally, set |response| to a [=response/clone=] of |response|.
 
        <p class="note">An implementation might wish to do this if it believes that the prefetch will be consumed more than once. For example, if in the future the response is consumed by a prerender, that [=prerendering traversable=] might be [=destroy a top-level traversable|destroyed=] through various means. Normally that would mean the response is discarded, but if the implementation performs this step, then the prefetched response will still be available to serve a future navigation. [[PRERENDERING-REVAMPED]]
     1. If the user agent did not perform the previous optional step, then it must [=list/remove=] |record| from |navigable|'s [=navigable/active document=]'s [=Document/prefetch records=].
-    1. <span id="prefetch-activation-client-creation"></span>Let |reservedEnvironment| be a new [=environment=] with:
-        : [=environment/id=]
-        :: a unique opaque string
-        : [=environment/creation URL=]
-        :: |request|'s [=request/reserved client=]'s [=environment/creation URL=]
-        : [=environment/top-level creation URL=]
-        :: |request|'s [=request/reserved client=]'s [=environment/top-level creation URL=]
-        : [=environment/top-level origin=]
-        :: |request|'s [=request/reserved client=]'s [=environment/top-level origin=]
-        : [=environment/target browsing context=]
-        :: |request|'s [=request/reserved client=]'s [=environment/target browsing context=]
-        : [=environment/active service worker=]
-        :: |record|'s [=prefetch record/redirect chain=]'s last item's [=exchange record/request=]'s [=request/reserved client=]'s [=environment/active service worker=]
-        : [=environment/execution ready flag=]
-        :: |request|'s [=request/reserved client=]'s [=environment/execution ready flag=]
-
-        <p class="note">We need a separate [=environment=] for each time a [=prefetch record=] is consumed, instead of using |request|'s [=request/reserved client=], because otherwise reusing the same prefetch record for multiple [=navigation params=] (i.e., multiple navigations) would cause the created [=environment settings objects=] to share an [=environment/id=]. This would then be visible, e.g., through the {{Clients/get()|clients.get()}} API, in a very confusing way.
     1. Return a new [=navigation params=], with:
         :  [=navigation params/id=]
         :: |navigationId|
@@ -413,7 +403,7 @@ The user agent may [=prefetch record/cancel and discard=] records from the [=Doc
         :  [=navigation params/COOP enforcement result=]
         :: |coopEnforcementResult|
         :  [=navigation params/reserved environment=]
-        :: |reservedEnvironment|
+        :: |request|'s [=request/reserved client=]
         :  [=navigation params/navigable=]
         :: |navigable|
         :  [=navigation params/navigation timing type=]
@@ -559,9 +549,6 @@ Modify the [=snapshot source snapshot params=] algorithm to set the return value
             1. If <var ignore>documentResource</var> is null:
               1. Let |prefetchRecord| be the result of [=finding a matching complete prefetch record=] given <var ignore>navigable</var>, <var ignore>sourceSnapshotParams</var>, <var ignore>entry</var>'s [=session history entry/URL=], and <var ignore>sourceSnapshotParams</var>'s [=source snapshot params/sandboxing flags=].
               1. If |prefetchRecord| is not null:
-                1. Set |request|'s [=request/reserved client=] to the result of [=creating a reserved client=] given <var ignore>navigable</var>, |request|'s [=request/current URL=], and null.
-                  <p class="note">This [=environment=] is never actually exposed as a client; instead, it is used to hold some data and then cloned into an actual client <a href="#prefetch-activation-client-creation">shortly</a>.
-                1. Set |request|'s [=request/reserved client=]'s [=environment/is navigational prefetch client=] to true.
                 1. Set <var ignore>navigationParams</var> to the result of [=creating navigation params from a prefetch record=] given <var ignore>navigable</var>, <var ignore>entry</var>'s [=session history entry/document state=], <var ignore>navigationId</var>, <var ignore>navTimingType</var>, <var ignore>request</var>, |prefetchRecord|, <var ignore>targetSnapshotParams</var>, and <var ignore>sourceSnapshotParams</var>.
                 1. [=Copy prefetch cookies=] given |prefetchRecord|'s [=prefetch record/isolated partition key=] and <var ignore>navigationParams</var>'s [=navigation params/reserved environment=].
 

--- a/prefetch.bs
+++ b/prefetch.bs
@@ -378,8 +378,23 @@ The user agent may [=prefetch record/cancel and discard=] records from the [=Doc
 
        <p class="note">An implementation might wish to do this if it believes that the prefetch will be consumed more than once. For example, if in the future the response is consumed by a prerender, that [=prerendering traversable=] might be [=destroy a top-level traversable|destroyed=] through various means. Normally that would mean the response is discarded, but if the implementation performs this step, then the prefetched response will still be available to serve a future navigation. [[PRERENDERING-REVAMPED]]
     1. If the user agent did not perform the previous optional step, then it must [=list/remove=] |record| from |navigable|'s [=navigable/active document=]'s [=Document/prefetch records=].
+    1. <span id="prefetch-activation-client-creation"></span>Let |reservedEnvironment| be a new [=environment=] with:
+        : [=environment/id=]
+        :: a unique opaque string
+        : [=environment/creation URL=]
+        :: |request|'s [=request/reserved client=]'s [=environment/creation URL=]
+        : [=environment/top-level creation URL=]
+        :: |request|'s [=request/reserved client=]'s [=environment/top-level creation URL=]
+        : [=environment/top-level origin=]
+        :: |request|'s [=request/reserved client=]'s [=environment/top-level origin=]
+        : [=environment/target browsing context=]
+        :: |request|'s [=request/reserved client=]'s [=environment/target browsing context=]
+        : [=environment/active service worker=]
+        :: |request|'s [=request/reserved client=]'s [=environment/active service worker=]
+        : [=environment/execution ready flag=]
+        :: |request|'s [=request/reserved client=]'s [=environment/execution ready flag=]
 
-
+        <p class="note">We need a separate [=environment=] for each time a [=prefetch record=] is consumed, instead of using |request|'s [=request/reserved client=], because otherwise reusing the same prefetch record for multiple [=navigation params=] (i.e., multiple navigations) would cause the created [=environment settings objects=] to share an [=environment/id=]. This would then be visible, e.g., through the {{Clients/get()|clients.get()}} API, in a very confusing way.
     1. Return a new [=navigation params=], with:
         :  [=navigation params/id=]
         :: |navigationId|
@@ -398,7 +413,7 @@ The user agent may [=prefetch record/cancel and discard=] records from the [=Doc
         :  [=navigation params/COOP enforcement result=]
         :: |coopEnforcementResult|
         :  [=navigation params/reserved environment=]
-        :: |request|'s [=request/reserved client=]
+        :: |reservedEnvironment|
         :  [=navigation params/navigable=]
         :: |navigable|
         :  [=navigation params/navigation timing type=]
@@ -539,6 +554,8 @@ Modify the [=snapshot source snapshot params=] algorithm to set the return value
             1. If <var ignore>documentResource</var> is null:
               1. Let |prefetchRecord| be the result of [=finding a matching complete prefetch record=] given <var ignore>navigable</var>, <var ignore>sourceSnapshotParams</var>, <var ignore>entry</var>'s [=session history entry/URL=], and <var ignore>sourceSnapshotParams</var>'s [=source snapshot params/sandboxing flags=].
               1. If |prefetchRecord| is not null:
+                1. Set |request|'s [=request/reserved client=] to the result of [=creating a reserved client=] given <var ignore>navigable</var>, |request|'s [=request/current URL=], and null.
+                  <p class="note">This [=environment=] is never actually exposed as a client; instead, it is used to hold some data and then cloned into an actual client <a href="#prefetch-activation-client-creation">shortly</a>.
                 1. Set <var ignore>navigationParams</var> to the result of [=creating navigation params from a prefetch record=] given <var ignore>navigable</var>, <var ignore>entry</var>'s [=session history entry/document state=], <var ignore>navigationId</var>, <var ignore>navTimingType</var>, <var ignore>request</var>, |prefetchRecord|, <var ignore>targetSnapshotParams</var>, and <var ignore>sourceSnapshotParams</var>.
                 1. [=Copy prefetch cookies=] given |prefetchRecord|'s [=prefetch record/isolated partition key=] and <var ignore>navigationParams</var>'s [=navigation params/reserved environment=].
 
@@ -717,6 +734,20 @@ This section contains patches to [[NAVIGATION-TIMING]].
 
 <div algorithm="create the navigation timing entry">
     Add an additional parameter to [=create the navigation timing entry=], which is a [=string=] <var ignore>deliveryType</var>, and pass it as an additional argument to [=setup the resource timing entry=].
+</div>
+
+<h2 id="service-workers-patches">Service Workers Patches</h2>
+
+This section contains patches to [[SERVICE-WORKERS]].
+
+<div algorithm="Create Fetch Event and Dispatch">
+  Modify <a spec="SERVICE-WORKERS">Create Fetch Event and Dispatch</a>'s step which sets {{FetchEvent/resultingClientId}} as follows:
+
+  <blockquote>
+    If |request| is a [=non-subresource request=] and |request|'s [=request/destination=] is not "{{RequestDestination/report}}"<ins> and |request|'s [=request/header list=] does not contain a [=header=] whose [=header/name=] is [:Sec-Purpose:]</ins>, initialize <var ignore>e</var>'s {{FetchEvent/resultingClientId}} attribute to <var ignore>reservedClient</var>'s [=environment/id=], and to the empty string otherwise.
+  </blockquote>
+
+  <p class="note">Although |request|'s has a [=request/reserved client=] at this time, it is just a specification fiction to help the request go through. It does not represent an actual client, of the sort that can be seen in e.g. {{Clients/matchAll()|clients.matchAll()}}. Actual client creation happens <a href="#prefetch-activation-client-creation">at activation time</a>, which will be after the {{FetchEvent}} is done firing.
 </div>
 
 <h2 id="clear-site-data-patches">Clear Site Data patches</h2>

--- a/prefetch.bs
+++ b/prefetch.bs
@@ -390,7 +390,7 @@ The user agent may [=prefetch record/cancel and discard=] records from the [=Doc
         : [=environment/target browsing context=]
         :: |request|'s [=request/reserved client=]'s [=environment/target browsing context=]
         : [=environment/active service worker=]
-        :: |request|'s [=request/reserved client=]'s [=environment/active service worker=]
+        :: |record|'s [=prefetch record/redirect chain=]'s last item's [=exchange record/request=]'s [=request/reserved client=]'s [=environment/active service worker=]
         : [=environment/execution ready flag=]
         :: |request|'s [=request/reserved client=]'s [=environment/execution ready flag=]
 

--- a/prefetch.bs
+++ b/prefetch.bs
@@ -446,6 +446,11 @@ A <dfn export>cross-origin prefetch IP anonymization policy</dfn> has an <dfn ex
 
 This section contains patches to [[HTML]].
 
+Add an additional item to [=environment=] as follows:
+
+: <dfn for="environment">is navigational prefetch client</dfn>
+:: a [=boolean=] (default false)
+
 Add an additional item to [=navigation params=] as follows:
 :  <dfn for="navigation params">delivery type</dfn>
 :: a [=string=] (corresponding to {{PerformanceResourceTiming}} [=PerformanceResourceTiming/delivery type=])
@@ -556,6 +561,7 @@ Modify the [=snapshot source snapshot params=] algorithm to set the return value
               1. If |prefetchRecord| is not null:
                 1. Set |request|'s [=request/reserved client=] to the result of [=creating a reserved client=] given <var ignore>navigable</var>, |request|'s [=request/current URL=], and null.
                   <p class="note">This [=environment=] is never actually exposed as a client; instead, it is used to hold some data and then cloned into an actual client <a href="#prefetch-activation-client-creation">shortly</a>.
+                1. Set |request|'s [=request/reserved client=]'s [=environment/is navigational prefetch client=] to true.
                 1. Set <var ignore>navigationParams</var> to the result of [=creating navigation params from a prefetch record=] given <var ignore>navigable</var>, <var ignore>entry</var>'s [=session history entry/document state=], <var ignore>navigationId</var>, <var ignore>navTimingType</var>, <var ignore>request</var>, |prefetchRecord|, <var ignore>targetSnapshotParams</var>, and <var ignore>sourceSnapshotParams</var>.
                 1. [=Copy prefetch cookies=] given |prefetchRecord|'s [=prefetch record/isolated partition key=] and <var ignore>navigationParams</var>'s [=navigation params/reserved environment=].
 
@@ -602,7 +608,9 @@ Modify the [=snapshot source snapshot params=] algorithm to set the return value
             1. Run the [=environment discarding steps=] for |request|'s [=request/reserved client=].
             1. Set |request|'s [=request/reserved client=] to null.
             1. Set |commitEarlyHints| to null.
-        1. If |request|'s [=request/reserved client=] is null, then set |request|'s [=request/reserved client=] to the result of [=creating a reserved client=] given |navigable|, |currentURL| and |isolationOrigin|.
+        1. If |request|'s [=request/reserved client=] is null, then:
+          1. Set |request|'s [=request/reserved client=] to the result of [=creating a reserved client=] given |navigable|, |currentURL| and |isolationOrigin|.
+          1. If |prefetchRecord| was given, then set |request|'s [=request/reserved client=]'s [=environment/is navigational prefetch client=] to true.
         1. If the result of [=should navigation request of type be blocked by Content Security Policy?=] given |request| and |cspNavigationType| is "`Blocked`", then set |response| to a [=network error=] and [=iteration/break=]. [[CSP]]
         1. If |prefetchRecord| was given, then:
             1. Let |purpose| be a [=structured header/List=] containing the [=structured header/Token=] `prefetch`.
@@ -744,10 +752,10 @@ This section contains patches to [[SERVICE-WORKERS]].
   Modify <a spec="SERVICE-WORKERS">Create Fetch Event and Dispatch</a>'s step which sets {{FetchEvent/resultingClientId}} as follows:
 
   <blockquote>
-    If |request| is a [=non-subresource request=] and |request|'s [=request/destination=] is not "{{RequestDestination/report}}"<ins> and |request|'s [=request/header list=] does not contain a [=header=] whose [=header/name=] is [:Sec-Purpose:]</ins>, initialize <var ignore>e</var>'s {{FetchEvent/resultingClientId}} attribute to <var ignore>reservedClient</var>'s [=environment/id=], and to the empty string otherwise.
+    If |request| is a [=non-subresource request=] and |request|'s [=request/destination=] is not "{{RequestDestination/report}}"<ins> and |reservedClient|'s [=environment/is navigational prefetch client=] is false</ins>, initialize <var ignore>e</var>'s {{FetchEvent/resultingClientId}} attribute to |reservedClient|'s [=environment/id=], and to the empty string otherwise.
   </blockquote>
 
-  <p class="note">Although |request|'s has a [=request/reserved client=] at this time, it is just a specification fiction to help the request go through. It does not represent an actual client, of the sort that can be seen in e.g. {{Clients/matchAll()|clients.matchAll()}}. Actual client creation happens <a href="#prefetch-activation-client-creation">at activation time</a>, which will be after the {{FetchEvent}} is done firing.
+  <p class="note">In the prefetch case, although |request| has a [=request/reserved client=] at this time, it is just a specification fiction to help the request go through. It does not represent an actual client, of the sort that can be seen in e.g. {{Clients/matchAll()|clients.matchAll()}}. Actual client creation happens <a href="#prefetch-activation-client-creation">at activation time</a>, which will be after the {{FetchEvent}} is done firing.
 </div>
 
 <h2 id="clear-site-data-patches">Clear Site Data patches</h2>
@@ -782,8 +790,6 @@ Modify <a abstract-op spec="CLEAR-SITE-DATA">clear site data for response</a>'s 
 </div>
 
 <h2 id="prefetch-algorithms">Prefetch algorithms</h2>
-
-<p class="issue">Check Service Worker integration</p>
 
 The <dfn>list of sufficiently strict speculative navigation referrer policies</dfn> is a list containing the following: "", "`strict-origin-when-cross-origin`", "`strict-origin`", "`same-origin`", "`no-referrer`".
 

--- a/prefetch.bs
+++ b/prefetch.bs
@@ -748,6 +748,16 @@ This section contains patches to [[NAVIGATION-TIMING]].
 
 This section contains patches to [[SERVICE-WORKERS]].
 
+<div algorithm="Service worker control">
+  Modify the definition of <a spec="SERVICE-WORKERS">controlled</a> as follows:
+
+  <blockquote>
+    When a [=service worker client=] has a non-null [=environment/active service worker=]<ins> whose [=environment/is navigational prefetch client=] is false</ins>, it is said to be <dfn noexport>controlled</dfn> by that [=environment/active service worker=].
+  </blockquote>
+</div>
+
+<hr>
+
 <div algorithm="Create Fetch Event and Dispatch">
   Modify <a spec="SERVICE-WORKERS">Create Fetch Event and Dispatch</a>'s step which sets {{FetchEvent/resultingClientId}} as follows:
 


### PR DESCRIPTION
Fixes #346. In particular:

* Fixed prefetch activation to use the correct reserved clients. Previously, the prefetch activation parts of the specification (in "create a navigation params from a prefetch record") would assume that the request they were being passed had a reserved client, when in reality they did not, because "create a navigation request" did not set a reserved client. We change them to consult the reserved clients from the redirect chain, which is more correct anyway.

* Properly creates a new reserved environment during each prefetch activation, by creating a new environment with correct values, including the active service worker. This is necessary to avoid prefetch record reuse from causing the creation of multiple clients with the same ID.

* Makes the resultingClientId on the FetchEvent that occurs during prefetch be the empty string. The client ID is not known at the time of the prefetch, so this is the only possibility that makes sense.


@hiroshige-g PTAL!