### PR TITLE
Delay background sync while prerendering

### DIFF
--- a/prerendering.bs
+++ b/prerendering.bs
@@ -945,6 +945,10 @@ Add {{[DelayWhilePrerendering]}} to {{PushManager/subscribe()}}.
 
 Add {{[DelayWhilePrerendering]}} to {{BackgroundFetchManager/fetch()}}.
 
+<h4 id="background-sync-patch">Background Sync</h4>
+
+Add {{[DelayWhilePrerendering]}} to {{SyncManager/register()}}.
+
 <h4 id="persist-patch">Storage API</h4>
 
 Add {{[DelayWhilePrerendering]}} to {{StorageManager/persist()}}.


### PR DESCRIPTION
Closes #354.

The only relevant background sync API accessible from Windows is serviceWorkerRegistration.sync.register(). This registers a sync to happen later when the user is online.

At first I thought allowing this to happen while prerendering might be OK. However, the method explicitly throws an exception if it's used when there are no top-level/auxiliary clients. https://developer.chrome.com/blog/background-sync/ seems to imply this is an abuse prevention measure: "You can only register for a sync event when the user has a window open to the site."

So, we decide to delay any background sync registrations while prerendering.

Already tested in https://github.com/web-platform-tests/wpt/blob/8751dfbd9d/speculation-rules/prerender/restriction-background-sync.tentative.https.html.