### PR TITLE
Cancel prerenders on speculation rules removal

### DIFF
--- a/prefetch.bs
+++ b/prefetch.bs
@@ -237,9 +237,10 @@ The user agent may [=prefetch record/cancel and discard=] records from the [=Doc
     1. [=Assert=]: |prefetchRecord|'s [=prefetch record/state=] is not "`canceled`".
     1. Set |prefetchRecord|'s [=prefetch record/state=] to "`canceled`".
     1. [=fetch controller/Abort=] |prefetchRecord|'s [=prefetch record/fetch controller=]. <span class="note">This will cause any ongoing fetch to be canceled and yield a [=network error=].</span>
+    1. If |prefetchRecord|'s [=prefetch record/prerendering traversable=] is a [=traversable navigable=], then [=destroy a top-level traversable|destroy=] it.
     1. [=list/Remove=] |prefetchRecord| from |document|'s [=Document/prefetch records=].
 
-    <div class="note">This means that even a completed prefetch will not be served from the prefetch buffer. However, if it was part of the same partition as the document which requested it, it might still be stored in the ordinary HTTP cache.</div>
+    <p class="note">This means that even a completed prefetch or prerender will not be activated. However, the process of prefetching or prerendering might have modified the HTTP cache, making subsequent navigations faster anyway.</p>
 </div>
 
 <div algorithm>
@@ -747,6 +748,7 @@ Modify <a abstract-op spec="CLEAR-SITE-DATA">clear site data for response</a>'s 
       1. Let |activeDocument| be the |navigable|'s [=navigable/active document=].
       1. If |activeDocument|'s [=Document/origin=] is not [=same origin=] with |origin|, then [=iteration/continue=].
       1. [=list/For each=] |prefetchRecord| in |activeDocument|'s [=Document/prefetch records=]:
+        1. If |prefetchRecord|'s [=prefetch record/prerendering traversable=] is not null, then [=iteration/continue=].
         1. [=prefetch record/Cancel and discard=] |prefetchRecord| given |activeDocument|.
 </div>
 

--- a/prerendering.bs
+++ b/prerendering.bs
@@ -670,7 +670,13 @@ Modify <a abstract-op spec="CLEAR-SITE-DATA">clear site data for response</a>'s 
   To <dfn>clear prerender cache</dfn> given an [=origin=] |origin|:
 
   1. [=list/For each=] [=navigable/top-level traversable=] |traversable| of the user agent's [=user agent/top-level traversable set=]:
-    1. If |traversable|'s [=navigable/active document=]'s [=Document/origin=] is [=same origin=] with |origin|, and |traversable| is a [=prerendering traversable=], then [=destroy a top-level traversable|destroy=] |traversable|.
+    1. Let |navigables| be the [=Document/inclusive descendant navigables=] of |traversable|'s [=navigable/active document=].
+    1. [=list/For each=] |navigable| in |navigables|:
+      1. Let |activeDocument| be the |navigable|'s [=navigable/active document=].
+      1. If |activeDocument|'s [=Document/origin=] is not [=same origin=] with |origin|, then [=iteration/continue=].
+      1. [=list/For each=] |prefetchRecord| in |activeDocument|'s [=Document/prefetch records=]:
+        1. If |prefetchRecord|'s [=prefetch record/prerendering traversable=] is null, then [=iteration/continue=].
+        1. [=prefetch record/Cancel and discard=] |prefetchRecord| given |activeDocument|.
 </div>
 
 <h2 id="supports-loading-mode">The \`<dfn export http-header><code>Supports-Loading-Mode</code></dfn>\` HTTP response header</h2>

--- a/speculation-rules.bs
+++ b/speculation-rules.bs
@@ -573,12 +573,14 @@ A <dfn>prerender candidate</dfn> is a [=speculative load candidate=] with the fo
 </div>
 
 <div algorithm>
-  A [=prefetch candidate=] |prefetchCandidate| <dfn for="prefetch candidate">continues</dfn> a [=prefetch record=] |prefetchRecord| if the following are all true:
-  * |prefetchRecord|'s [=prefetch record/label=] is "`speculation-rules`"
-  * |prefetchRecord|'s [=prefetch record/state=] is not "`canceled`"
-  * |prefetchRecord| [=prefetch record/matches a URL=] given |prefetchCandidate|'s [=speculative load candidate/URL=]
-  * |prefetchRecord|'s [=prefetch record/anonymization policy=] equals |prefetchCandidate|'s [=prefetch candidate/anonymization policy=]
+  A [=prefetch record=] |prefetchRecord| is <dfn for="prefetch record">still being speculated</dfn>, given a list of [=speculative load candidates=] |candidates|, if the following steps return true:
 
+  1. [=list/For each=] |candidate| of |candidates|:
+    1. If |prefetchRecord| does not [=prefetch record/match a URL=] given |candidate|'s [=speculative load candidate/URL=], then [=iteration/continue=].
+    1. If |candidate| is a [=prefetch candidate=] and |prefetchRecord|'s [=prefetch record/anonymization policy=] does not equal |candidate|'s [=prefetch candidate/anonymization policy=], then [=iteration/continue=].
+    1. If |candidate| is a [=prerender candidate=] and |prefetchRecord|'s [=prefetch record/prerendering traversable=] is null, then [=iteration/continue=].
+    1. Return true.
+  1. Return false.
 </div>
 
 <div algorithm>
@@ -730,10 +732,11 @@ A <dfn>prerender candidate</dfn> is a [=speculative load candidate=] with the fo
               </dl>
 
               to |prerenderCandidates|.
+    1. Let |speculativeLoadCandidates| be the union of |prefetchCandidates| and |prerenderCandidates|.
     1. [=list/For each=] |prefetchRecord| of |document|'s [=Document/prefetch records=]:
       1. If |prefetchRecord|'s [=prefetch record/label=] is not "`speculation-rules`", then [=iteration/continue=].
       1. [=Assert=]: |prefetchRecord|'s [=prefetch record/state=] is not "`canceled`".
-      1. If no element of |prefetchCandidates| [=prefetch candidate/continues=] |prefetchRecord|, then [=prefetch record/cancel and discard=] |prefetchRecord| given |document|.
+      1. If |prefetchRecord| is not [=prefetch record/still being speculated=] given |speculativeLoadCandidates|, then [=prefetch record/cancel and discard=] |prefetchRecord| given |document|.
     1. [=list/For each=] |prefetchCandidate| of |prefetchCandidates|:
       1. The user agent may run the following steps:
         1. Let |prefetchAndPrerenderCandidates| be an empty [=list=].


### PR DESCRIPTION
Closes #355.

Also fixes some fallout from the unification of prefetch and prerender in 3f24fad9c0a6a3ed0d9aafd524a87771d2899434. Because all prerenders also lived as prefetch records, previously some of the spec (like prefetch Clear-Site-Data) was overeager in destroying them. And some of the spec (like prerender Clear-Site-Data) did not properly clean them up.