### PR TITLE
Editorial: fix broken external links

### DIFF
--- a/prefetch.bs
+++ b/prefetch.bs
@@ -112,7 +112,6 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
       text: cross-origin prefetch IP anonymization policy; url: cross-origin-prefetch-ip-anonymization-policy
       text: prefetch candidate; url: prefetch-candidate
       text: prefetch IP anonymization policy; url: prefetch-ip-anonymization-policy
-      text: prerender candidate; url: prerender-candidate
       text: speculation rule tag; url: speculation-rule-tag
       text: speculative load candidate; url: speculative-load-candidate
       for: cross-origin prefetch IP anonymization policy
@@ -142,8 +141,9 @@ spec: COOKIES; urlPrefix: https://httpwg.org/specs/rfc6265.html
 spec: prerendering-revamped; urlPrefix: prerendering.html
   type: dfn
     text: getting the supported loading modes; url: get-the-supported-loading-modes
-    text: prerendering navigable; url: prerendering-navigable
-    text: prerendering traversable; url: prerendering-traversable
+    text: prerendering navigable
+    text: prerendering traversable
+    text: prerender candidate
 spec: no-vary-search; urlPrefix: https://httpwg.org/http-extensions/draft-ietf-httpbis-no-vary-search.html
   type: dfn
     text: URL search variance; url: name-data-model

--- a/prerendering.bs
+++ b/prerendering.bs
@@ -50,9 +50,9 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
     text: the worker's lifetime; url: workers.html#the-worker's-lifetime
     text: URL and history update steps; url: browsing-the-web.html#url-and-history-update-steps
     text: collecting tags from speculative load candidates; url: speculative-loading.html#collect-tags-from-speculative-load-candidates
-    text: compute a speculative load referrer policy; url: speculative-loading.html#compute-speculative-load-referrer-policy
+    text: compute a speculative load referrer policy; url: speculative-loading.html#compute-a-speculative-load-referrer-policy
     text: consider speculative loads; url: speculative-loading.html#consider-speculative-loads
-    text: finding matching links; url: speculative-loading.html#finding-matching-links
+    text: find matching links; url: speculative-loading.html#find-matching-links
     text: inner consider speculative loads steps; url: speculative-loading.html#inner-consider-speculative-loads-steps
     text: parse a speculation rule set string; url: speculative-loading.html#speculation-rule-set
     text: parse a speculation rule; url: speculative-loading.html#parse-a-speculation-rule


### PR DESCRIPTION
This is one of the perils of manually curating one's anchor block in monkeypatch specs.

Closes #413.  Closes #414.