### PR TITLE
Fix broken link to picture-in-picture algorithm

### DIFF
--- a/prerendering.bs
+++ b/prerendering.bs
@@ -114,9 +114,6 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
 spec: battery; urlPrefix: https://w3c.github.io/battery/
   type: dfn
     text: [[BatteryPromise]]; url: dfn-batterypromise
-spec: picture-in-picture; urlPrefix: https://w3c.github.io/picture-in-picture/
-  type: dfn
-    text: request Picture-in-Picture; url: request-picture-in-picture-algorithm
 spec: mediacapture-main; urlPrefix: https://w3c.github.io/mediacapture-main/
   type: dfn
     text: device change notification steps; url: dfn-device-change-notification-steps


### PR DESCRIPTION
The previous fragment is no longer valid. This update drops the hardcoded URL so that Bikeshed can leverage the more up-to-date xref database and adjust the fragment over time.